### PR TITLE
feature/initial integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Addon package directory
 /package/*
 
+client/ayon_speedtree/api/sdk/speedtree
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/client/ayon_speedtree/__init__.py
+++ b/client/ayon_speedtree/__init__.py
@@ -1,0 +1,14 @@
+from .version import __version__
+from .addon import (
+    SPTREE_ADDON_ROOT,
+    SpeedtreeAddon,
+    get_launch_script_path
+)
+
+
+__all__ = (
+    "__version__",
+    "get_launch_script_path",
+    "SPTREE_ADDON_ROOT",
+    "SpeedtreeAddon",
+)

--- a/client/ayon_speedtree/addon.py
+++ b/client/ayon_speedtree/addon.py
@@ -1,0 +1,56 @@
+import os
+from ayon_core.addon import AYONAddon, IHostAddon
+
+from .version import __version__
+
+SPTREE_ADDON_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_launch_script_path():
+    return os.path.join(
+        SPTREE_ADDON_ROOT,
+        "api",
+        "launch_script.py"
+    )
+
+
+class SpeedtreeAddon(AYONAddon, IHostAddon):
+    name = "speedtree"
+    version = __version__
+    host_name = "speedtree"
+
+    def add_implementation_envs(self, env, app):
+        # Add AYON zscripts
+        # new_speedtree_paths = [
+        #     os.path.join(SPTREE_ADDON_ROOT, "api", "sdk")
+        # ]
+        # old_speedtree_path = env.get("SPTREE_SDK_PATH") or ""
+        # for path in old_speedtree_path.split(os.pathsep):
+        #     if not path:
+        #         continue
+        #     norm_path = os.path.normpath(path)
+        #     if norm_path not in new_speedtree_paths:
+        #         new_speedtree_paths.append(norm_path)
+        # env["SPTREE_SDK_PATH"] = os.pathsep.join(new_speedtree_paths)
+
+        # Set default environments if are not set via settings
+        defaults = {
+            "AYON_LOG_NO_COLORS": "1",
+            "WEBSOCKET_URL": "ws://localhost:6010"
+        }
+        for key, value in defaults.items():
+            if not env.get(key):
+                env[key] = value
+
+        # Remove auto screen scale factor for Qt
+        env.pop("QT_AUTO_SCREEN_SCALE_FACTOR", None)
+
+    def get_launch_hook_paths(self, app):
+        if app.host_name != self.host_name:
+            return []
+        return [
+            os.path.join(SPTREE_ADDON_ROOT, "hooks")
+        ]
+
+    def get_workfile_extensions(self):
+        return [".spm"]

--- a/client/ayon_speedtree/addon.py
+++ b/client/ayon_speedtree/addon.py
@@ -20,18 +20,18 @@ class SpeedtreeAddon(AYONAddon, IHostAddon):
     host_name = "speedtree"
 
     def add_implementation_envs(self, env, app):
-        # Add AYON zscripts
-        # new_speedtree_paths = [
-        #     os.path.join(SPTREE_ADDON_ROOT, "api", "sdk")
-        # ]
-        # old_speedtree_path = env.get("SPTREE_SDK_PATH") or ""
-        # for path in old_speedtree_path.split(os.pathsep):
-        #     if not path:
-        #         continue
-        #     norm_path = os.path.normpath(path)
-        #     if norm_path not in new_speedtree_paths:
-        #         new_speedtree_paths.append(norm_path)
-        # env["SPTREE_SDK_PATH"] = os.pathsep.join(new_speedtree_paths)
+        new_python_paths = [
+            os.path.join(
+                SPTREE_ADDON_ROOT, "api", "sdk")
+        ]
+        old_python_path = env.get("PYTHONPATH") or ""
+        for path in old_python_path.split(os.pathsep):
+            if not path:
+                continue
+            norm_path = os.path.normpath(path)
+            if norm_path not in new_python_paths:
+                new_python_paths.append(norm_path)
+        env["PYTHONPATH"] = os.pathsep.join(new_python_paths)
 
         # Set default environments if are not set via settings
         defaults = {

--- a/client/ayon_speedtree/api/__init__.py
+++ b/client/ayon_speedtree/api/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Public API for Speedtree"""
+from .communication_server import CommunicationWrapper
+from .pipeline import SpeedtreeHost
+
+__all__ = [
+    "CommunicationWrapper",
+    "SpeedtreeHost"
+]

--- a/client/ayon_speedtree/api/communication_server.py
+++ b/client/ayon_speedtree/api/communication_server.py
@@ -471,14 +471,17 @@ class BaseCommunicator:
         Replace the current subprocess with a new one.
 
         Args:
-            new_process_args (list): The arguments to pass to the new subprocess.
+            new_process_args (list): The arguments to pass to the
+                                     new subprocess.
         """
         # Terminate the current process if it's running
         prev_process = self.process
         self._launch_speedtree(new_process_args)
         if prev_process and prev_process.poll() is None:
-            prev_process.terminate()  # or self.process.kill() for forceful termination
-            prev_process.wait()  # Wait for the process to terminate
+            # or self.process.kill() for forceful termination
+            prev_process.terminate()
+            # Wait for the process to terminate
+            prev_process.wait()
 
         log.info("Replaced subprocess with new process: {}".format(new_process_args))
 

--- a/client/ayon_speedtree/api/communication_server.py
+++ b/client/ayon_speedtree/api/communication_server.py
@@ -1,15 +1,15 @@
 import os
 import json
 import time
-import contextlib
+
 import subprocess
 import collections
 import asyncio
 import logging
 import socket
-import tempfile
+
 import threading
-import shutil
+
 from contextlib import closing
 
 from aiohttp import web
@@ -24,15 +24,6 @@ from ayon_core.lib import emit_event
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-
-
-@contextlib.contextmanager
-def delete_after(path):
-    """Delete path after context"""
-    try:
-        yield
-    finally:
-        os.remove(path)
 
 
 class CommunicationWrapper:
@@ -63,7 +54,7 @@ class CommunicationWrapper:
 
     @classmethod
     def execute_sptree_command(cls, sptree_command):
-        """Execute passed zscript in Speedtree."""
+        """Execute passed Speedtree command in Speedtree."""
         if not cls.communicator:
             return
         return cls.communicator.execute_sptree_command(sptree_command)

--- a/client/ayon_speedtree/api/communication_server.py
+++ b/client/ayon_speedtree/api/communication_server.py
@@ -53,11 +53,11 @@ class CommunicationWrapper:
         return cls.communicator.client()
 
     @classmethod
-    def execute_sptree_command(cls, sptree_command):
-        """Execute passed Speedtree command in Speedtree."""
+    def replace_process(cls, launch_args):
+        """Load spm file."""
         if not cls.communicator:
             return
-        return cls.communicator.execute_sptree_command(sptree_command)
+        return cls.communicator.replace_process(launch_args)
 
 
 class WebSocketServer:
@@ -466,6 +466,22 @@ class BaseCommunicator:
             return False
         return self.websocket_server.server_is_running
 
+    def replace_process(self, new_process_args: list):
+        """
+        Replace the current subprocess with a new one.
+
+        Args:
+            new_process_args (list): The arguments to pass to the new subprocess.
+        """
+        # Terminate the current process if it's running
+        prev_process = self.process
+        self._launch_speedtree(new_process_args)
+        if prev_process and prev_process.poll() is None:
+            prev_process.terminate()  # or self.process.kill() for forceful termination
+            prev_process.wait()  # Wait for the process to terminate
+
+        log.info("Replaced subprocess with new process: {}".format(new_process_args))
+
     def _launch_speedtree(self, launch_args):
         flags = (
             subprocess.DETACHED_PROCESS
@@ -587,13 +603,6 @@ class BaseCommunicator:
         self.websocket_rpc.send_notification(
             client, method, params
         )
-
-    def execute_sptree_command(self, sptree_command):
-        """Execute passed speedtree command in Speedtree."""
-        sptree_exe = os.environ["SPTREE_EXE"]
-
-        subprocess.call(
-            [sptree_exe, "--load", r"D:\speed_tree_spm\my_tree.spm"], shell=True)
 
 
 class QtCommunicator(BaseCommunicator):

--- a/client/ayon_speedtree/api/communication_server.py
+++ b/client/ayon_speedtree/api/communication_server.py
@@ -483,7 +483,10 @@ class BaseCommunicator:
             # Wait for the process to terminate
             prev_process.wait()
 
-        log.info("Replaced subprocess with new process: {}".format(new_process_args))
+        log.info(
+            "Replaced subprocess with new process: {}".format(
+            new_process_args)
+        )
 
     def _launch_speedtree(self, launch_args):
         flags = (

--- a/client/ayon_speedtree/api/communication_server.py
+++ b/client/ayon_speedtree/api/communication_server.py
@@ -1,0 +1,656 @@
+import os
+import json
+import time
+import contextlib
+import subprocess
+import collections
+import asyncio
+import logging
+import socket
+import tempfile
+import threading
+import shutil
+from contextlib import closing
+
+from aiohttp import web
+from aiohttp_json_rpc import JsonRpc
+from aiohttp_json_rpc.protocol import (
+    encode_request, encode_error, decode_msg, JsonRpcMsgTyp
+)
+from aiohttp_json_rpc.exceptions import RpcError
+
+from ayon_core.lib import emit_event
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+@contextlib.contextmanager
+def delete_after(path):
+    """Delete path after context"""
+    try:
+        yield
+    finally:
+        os.remove(path)
+
+
+class CommunicationWrapper:
+    # TODO add logs and exceptions
+    communicator = None
+
+    log = logging.getLogger("CommunicationWrapper")
+
+    @classmethod
+    def create_qt_communicator(cls, *args, **kwargs):
+        """Create communicator for Artist usage."""
+        communicator = QtCommunicator(*args, **kwargs)
+        cls.set_communicator(communicator)
+        return communicator
+
+    @classmethod
+    def set_communicator(cls, communicator):
+        if not cls.communicator:
+            cls.communicator = communicator
+        else:
+            cls.log.warning("Communicator was set multiple times.")
+
+    @classmethod
+    def client(cls):
+        if not cls.communicator:
+            return None
+        return cls.communicator.client()
+
+    @classmethod
+    def execute_sptree_command(cls, sptree_command):
+        """Execute passed zscript in Speedtree."""
+        if not cls.communicator:
+            return
+        return cls.communicator.execute_sptree_command(sptree_command)
+
+
+class WebSocketServer:
+    def __init__(self):
+        self.client = None
+
+        self.loop = asyncio.new_event_loop()
+        self.app = web.Application(loop=self.loop)
+        self.port = self.find_free_port()
+        self.websocket_thread = WebsocketServerThread(
+            self, self.port, loop=self.loop
+        )
+
+    @property
+    def server_is_running(self):
+        return self.websocket_thread.server_is_running
+
+    def add_route(self, *args, **kwargs):
+        self.app.router.add_route(*args, **kwargs)
+
+    @staticmethod
+    def find_free_port():
+        with closing(
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ) as sock:
+            sock.bind(("", 0))
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            port = sock.getsockname()[1]
+        return port
+
+    def get_port(self):
+        if self.port is not None:
+            return self.port
+
+    def start(self):
+        self.websocket_thread.start()
+
+    def stop(self):
+        try:
+            if self.websocket_thread.is_running:
+                log.debug("Stopping websocket server")
+                self.websocket_thread.is_running = False
+                self.websocket_thread.stop()
+        except Exception:
+            log.warning(
+                "Error has happened during Killing websocket server",
+                exc_info=True
+            )
+
+
+class WebsocketServerThread(threading.Thread):
+    """ Listener for websocket rpc requests.
+
+        It would be probably better to "attach" this to main thread (as for
+        example Speedtree needs to run something on main thread), but currently
+        it creates separate thread and separate asyncio event loop
+    """
+    def __init__(self, module, port, loop):
+        super(WebsocketServerThread, self).__init__()
+        self.is_running = False
+        self.server_is_running = False
+        self.port = port
+        self.module = module
+        self.loop = loop
+        self.runner = None
+        self.site = None
+        self.tasks = []
+
+    def run(self):
+        self.is_running = True
+
+        try:
+            log.debug("Starting websocket server")
+
+            self.loop.run_until_complete(self.start_server())
+
+            log.info(
+                "Running Websocket server on URL:"
+                " \"ws://localhost:{}\"".format(self.port)
+            )
+
+            asyncio.ensure_future(self.check_shutdown(), loop=self.loop)
+
+            self.server_is_running = True
+            self.loop.run_forever()
+
+        except Exception:
+            log.warning(
+                "Websocket Server service has failed", exc_info=True
+            )
+        finally:
+            self.server_is_running = False
+            # optional
+            self.loop.close()
+
+        self.is_running = False
+        log.info("Websocket server stopped")
+
+    async def start_server(self):
+        """ Starts runner and TCPsite """
+        self.runner = web.AppRunner(self.module.app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, "localhost", self.port)
+        await self.site.start()
+
+    def stop(self):
+        """Sets is_running flag to false, 'check_shutdown' shuts server down"""
+        self.is_running = False
+
+    async def check_shutdown(self):
+        """ Future that is running and checks if server should be running
+            periodically.
+        """
+        while self.is_running:
+            while self.tasks:
+                task = self.tasks.pop(0)
+                log.debug("waiting for task {}".format(task))
+                await task
+                log.debug("returned value {}".format(task.result))
+
+            await asyncio.sleep(0.5)
+
+        log.debug("## Server shutdown started")
+
+        await self.site.stop()
+        log.debug("# Site stopped")
+        await self.runner.cleanup()
+        log.debug("# Server runner stopped")
+        tasks = [
+            task for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+        ]
+        list(map(lambda task: task.cancel(), tasks))  # cancel all the tasks
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        log.debug(f"Finished awaiting cancelled tasks, results: {results}...")
+        await self.loop.shutdown_asyncgens()
+        # to really make sure everything else has time to stop
+        await asyncio.sleep(0.07)
+        self.loop.stop()
+
+
+class BaseSpeedTreeRpc(JsonRpc):
+    def __init__(self, communication_obj, route_name="", **kwargs):
+        super().__init__(**kwargs)
+        self.requests_ids = collections.defaultdict(lambda: 0)
+        self.waiting_requests = collections.defaultdict(list)
+        self.responses = collections.defaultdict(list)
+
+        self.route_name = route_name
+        self.communication_obj = communication_obj
+
+    async def _handle_rpc_msg(self, http_request, raw_msg):
+        # This is duplicated code from super but there is no way how to do it
+        # to be able handle server->client requests
+        host = http_request.host
+        if host in self.waiting_requests:
+            try:
+                _raw_message = raw_msg.data
+                msg = decode_msg(_raw_message)
+
+            except RpcError as error:
+                await self._ws_send_str(http_request, encode_error(error))
+                return
+
+            if msg.type in (JsonRpcMsgTyp.RESULT, JsonRpcMsgTyp.ERROR):
+                msg_data = json.loads(_raw_message)
+                if msg_data.get("id") in self.waiting_requests[host]:
+                    self.responses[host].append(msg_data)
+                    return
+
+        return await super()._handle_rpc_msg(http_request, raw_msg)
+
+    def client_connected(self):
+        if self.communication_obj:
+            return True
+        return False
+
+    def send_notification(self, client, method, params=None):
+        if params is None:
+            params = []
+        asyncio.run_coroutine_threadsafe(
+            client.ws.send_str(encode_request(method, params=params)),
+            loop=self.loop
+        )
+
+    def send_request(self, client, method, params=None, timeout=0):
+        if params is None:
+            params = []
+
+        client_host = client.host
+
+        request_id = self.requests_ids[client_host]
+        self.requests_ids[client_host] += 1
+
+        self.waiting_requests[client_host].append(request_id)
+
+        log.debug("Sending request to client {} ({}, {}) id: {}".format(
+            client_host, method, params, request_id
+        ))
+        future = asyncio.run_coroutine_threadsafe(
+            client.ws.send_str(encode_request(method, request_id, params)),
+            loop=self.loop
+        )
+        result = future.result()
+
+        not_found = object()
+        response = not_found
+        start = time.time()
+        while True:
+            if client.ws.closed:
+                return None
+
+            for _response in self.responses[client_host]:
+                _id = _response.get("id")
+                if _id == request_id:
+                    response = _response
+                    break
+
+            if response is not not_found:
+                break
+
+            if timeout > 0 and (time.time() - start) > timeout:
+                raise Exception("Timeout passed")
+                return
+
+            time.sleep(0.1)
+
+        if response is not_found:
+            raise Exception("Connection closed")
+
+        self.responses[client_host].remove(response)
+
+        error = response.get("error")
+        result = response.get("result")
+        if error:
+            raise Exception("Error happened: {}".format(error))
+        return result
+
+
+class QtSpeedTreeRpc(BaseSpeedTreeRpc):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        from ayon_core.tools.utils import host_tools
+        self.tools_helper = host_tools.HostToolsHelper()
+
+        route_name = self.route_name
+
+        # Register methods
+        self.add_methods(
+            (route_name, self.workfiles_tool),
+            (route_name, self.loader_tool),
+            (route_name, self.publish_tool),
+            (route_name, self.scene_inventory_tool),
+            (route_name, self.library_loader_tool),
+            (route_name, self.experimental_tools)
+        )
+
+    # Panel routes for tools
+    async def workfiles_tool(self):
+        log.info("Triggering Workfile tool")
+        item = MainThreadItem(self.tools_helper.show_workfiles)
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def loader_tool(self):
+        log.info("Triggering Loader tool")
+        item = MainThreadItem(self.tools_helper.show_loader)
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def publish_tool(self):
+        log.info("Triggering Publish tool")
+        item = MainThreadItem(self.tools_helper.show_publisher_tool)
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def scene_inventory_tool(self):
+        """Open Scene Inventory tool.
+
+        Function can't confirm if tool was opened because one part of
+        SceneInventory initialization is calling websocket request to host but
+        host can't response because is waiting for response from this call.
+        """
+        log.info("Triggering Scene inventory tool")
+        item = MainThreadItem(self.tools_helper.show_scene_inventory)
+        # Do not wait for result of callback
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def library_loader_tool(self):
+        log.info("Triggering Library loader tool")
+        item = MainThreadItem(self.tools_helper.show_library_loader)
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def experimental_tools(self):
+        log.info("Triggering experimental tool")
+        item = MainThreadItem(self.tools_helper.show_experimental_tools_dialog)
+        self._execute_in_main_thread(item, wait=False)
+        return
+
+    async def _async_execute_in_main_thread(self, item, **kwargs):
+        await self.communication_obj.async_execute_in_main_thread(
+            item, **kwargs
+        )
+
+    def _execute_in_main_thread(self, item, **kwargs):
+        return self.communication_obj.execute_in_main_thread(item, **kwargs)
+
+
+class MainThreadItem:
+    """Structure to store information about callback in main thread.
+
+    Item should be used to execute callback in main thread which may be needed
+    for execution of Qt objects.
+
+    Item store callback (callable variable), arguments and keyword arguments
+    for the callback. Item hold information about it's process.
+    """
+    not_set = object()
+    sleep_time = 0.1
+
+    def __init__(self, callback, *args, **kwargs):
+        self.done = False
+        self.exception = self.not_set
+        self.result = self.not_set
+        self.callback = callback
+        self.args = args
+        self.kwargs = kwargs
+
+    def execute(self):
+        """Execute callback and store its result.
+
+        Method must be called from main thread. Item is marked as `done`
+        when callback execution finished. Store output of callback of exception
+        information when callback raises one.
+        """
+        log.debug("Executing process in main thread")
+        if self.done:
+            log.warning("- item is already processed")
+            return
+
+        callback = self.callback
+        args = self.args
+        kwargs = self.kwargs
+        log.info("Running callback: {}".format(str(callback)))
+        try:
+            result = callback(*args, **kwargs)
+            self.result = result
+
+        except Exception as exc:
+            self.exception = exc
+
+        finally:
+            self.done = True
+
+    def wait(self):
+        """Wait for result from main thread.
+
+        This method stops current thread until callback is executed.
+
+        Returns:
+            object: Output of callback. May be any type or object.
+
+        Raises:
+            Exception: Reraise any exception that happened during callback
+                execution.
+        """
+        while not self.done:
+            time.sleep(self.sleep_time)
+
+        if self.exception is self.not_set:
+            return self.result
+        raise self.exception
+
+    async def async_wait(self):
+        """Wait for result from main thread.
+
+        Returns:
+            object: Output of callback. May be any type or object.
+
+        Raises:
+            Exception: Reraise any exception that happened during callback
+                execution.
+        """
+        while not self.done:
+            await asyncio.sleep(self.sleep_time)
+
+        if self.exception is self.not_set:
+            return self.result
+        raise self.exception
+
+
+class BaseCommunicator:
+    def __init__(self):
+        self.process = None
+        self.websocket_server = None
+        self.websocket_rpc = None
+        self.exit_code = None
+        self._connected_client = None
+
+    @property
+    def server_is_running(self):
+        if self.websocket_server is None:
+            return False
+        return self.websocket_server.server_is_running
+
+    def _launch_speedtree(self, launch_args):
+        flags = (
+            subprocess.DETACHED_PROCESS
+            | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+        env = os.environ.copy()
+
+        kwargs = {
+            "env": env,
+            "creationflags": flags
+        }
+        self.process = subprocess.Popen(launch_args, **kwargs)
+
+    def _create_routes(self):
+        self.websocket_rpc = BaseSpeedTreeRpc(
+            self, loop=self.websocket_server.loop
+        )
+        self.websocket_server.add_route(
+            "*", "/", self.websocket_rpc.handle_request
+        )
+
+    def _start_webserver(self):
+        self.websocket_server.start()
+        # Make sure RPC is using same loop as websocket server
+        while not self.websocket_server.server_is_running:
+            time.sleep(0.1)
+
+    def _stop_webserver(self):
+        self.websocket_server.stop()
+
+    def _exit(self, exit_code=None):
+        self._stop_webserver()
+        if exit_code is not None:
+            self.exit_code = exit_code
+
+        if self.exit_code is None:
+            self.exit_code = 0
+
+    def stop(self):
+        """Stop communication and currently running python process."""
+        log.info("Stopping communication")
+        self._exit()
+
+    def launch(self, launch_args, sptree_host):
+        """Prepare all required data and launch host.
+
+        First is prepared websocket server as communication point for host,
+        when server is ready to use host is launched as subprocess.
+        """
+        # Launch Speedtree and the websocket server.
+        log.info("Launching Speedtree")
+        self.websocket_server = WebSocketServer()
+
+        self._create_routes()
+
+        os.environ["WEBSOCKET_URL"] = "ws://localhost:{}".format(
+            self.websocket_server.port
+        )
+
+        log.info("Added request handler for url: {}".format(
+            os.environ["WEBSOCKET_URL"]
+        ))
+
+        self._start_webserver()
+
+        # Start Speedtree when server is running
+        self._launch_speedtree(launch_args)
+
+        log.info("Waiting for client connection")
+        while True:
+            if self.process.poll() is not None:
+                log.debug("Host process is not alive. Exiting")
+                self._exit(1)
+                return
+
+            if self.websocket_rpc.client_connected():
+                log.info("Client has connected")
+                break
+            time.sleep(0.5)
+
+        self._on_client_connect(sptree_host)
+
+        emit_event("application.launched")
+
+    def _on_client_connect(self, sptree_host):
+        time.sleep(5)
+        sptree_host.show_tools_dialog()
+
+    def _client(self):
+        if not self.websocket_rpc:
+            log.warning("Communicator's server did not start yet.")
+            return None
+
+        for client in self.websocket_rpc.clients:
+            if not client.ws.closed:
+                return client
+        log.warning("Client is not yet connected to Communicator.")
+        return None
+
+    def client(self):
+        if not self._connected_client or self._connected_client.ws.closed:
+            self._connected_client = self._client()
+        return self._connected_client
+
+    def send_request(self, method, params=None):
+        client = self.client()
+        if not client:
+            return
+
+        return self.websocket_rpc.send_request(
+            client, method, params
+        )
+
+    def send_notification(self, method, params=None):
+        client = self.client()
+        if not client:
+            return
+
+        self.websocket_rpc.send_notification(
+            client, method, params
+        )
+
+    def execute_sptree_command(self, sptree_command):
+        """Execute passed speedtree command in Speedtree."""
+        sptree_exe = os.environ["SPTREE_EXE"]
+
+        subprocess.call(
+            [sptree_exe, "--load", r"D:\speed_tree_spm\my_tree.spm"], shell=True)
+
+
+class QtCommunicator(BaseCommunicator):
+
+    def __init__(self, qt_app):
+        super().__init__()
+        self.callback_queue = collections.deque()
+        self.qt_app = qt_app
+
+    def _create_routes(self):
+        self.websocket_rpc = QtSpeedTreeRpc(
+            self, loop=self.websocket_server.loop
+        )
+        self.websocket_server.add_route(
+            "*", "/", self.websocket_rpc.handle_request
+        )
+
+    def execute_in_main_thread(self, main_thread_item, wait=True):
+        """Add `MainThreadItem` to callback queue and wait for result."""
+        self.callback_queue.append(main_thread_item)
+        if wait:
+            return main_thread_item.wait()
+        return
+
+    async def async_execute_in_main_thread(self, main_thread_item, wait=True):
+        """Add `MainThreadItem` to callback queue and wait for result."""
+        self.callback_queue.append(main_thread_item)
+        if wait:
+            return await main_thread_item.async_wait()
+
+    def main_thread_listen(self):
+        """Get last `MainThreadItem` from queue.
+
+        Must be called from main thread.
+
+        Method checks if host process is still running as it may cause
+        issues if not.
+        """
+        # check if host still running
+        if self.process.poll() is not None:
+            self._exit()
+            return None
+
+        if self.callback_queue:
+            return self.callback_queue.popleft()
+        return None
+
+    def _exit(self, *args, **kwargs):
+        super()._exit(*args, **kwargs)
+        emit_event("application.exit")
+        self.qt_app.exit(self.exit_code)

--- a/client/ayon_speedtree/api/launch_script.py
+++ b/client/ayon_speedtree/api/launch_script.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import signal
+import traceback
+import ctypes
+import platform
+import logging
+
+from qtpy import QtWidgets, QtCore, QtGui
+
+from ayon_core import style
+from ayon_core.pipeline import install_host
+from ayon_speedtree.api import (
+    SpeedtreeHost,
+    CommunicationWrapper,
+)
+
+log = logging.getLogger(__name__)
+
+
+def safe_excepthook(*args):
+    traceback.print_exception(*args)
+
+
+def main(launch_args):
+    # Be sure server won't crash at any moment but just print traceback
+    sys.excepthook = safe_excepthook
+
+    # Create QtApplication for tools
+    # - QApplication is also main thread/event loop of the server
+    qt_app = QtWidgets.QApplication([])
+
+    sptree_host = SpeedtreeHost()
+    # Execute pipeline installation
+    install_host(sptree_host)
+
+    # Create Communicator object and trigger launch
+    # - this must be done before anything is processed
+    communicator = CommunicationWrapper.create_qt_communicator(qt_app)
+    communicator.launch(launch_args, sptree_host)
+
+    def process_in_main_thread():
+        """Execution of `MainThreadItem`."""
+        item = communicator.main_thread_listen()
+        if item:
+            item.execute()
+
+    timer = QtCore.QTimer()
+    timer.setInterval(100)
+    timer.timeout.connect(process_in_main_thread)
+    timer.start()
+
+    # Register terminal signal handler
+    def signal_handler(*_args):
+        print("You pressed Ctrl+C. Process ended.")
+        communicator.stop()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    qt_app.setQuitOnLastWindowClosed(False)
+    qt_app.setStyleSheet(style.load_stylesheet())
+
+    # Load avalon icon
+    icon_path = style.app_icon_path()
+    if icon_path:
+        icon = QtGui.QIcon(icon_path)
+        qt_app.setWindowIcon(icon)
+
+    # Set application name to be able show application icon in task bar
+    if platform.system().lower() == "windows":
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            u"WebsocketServer"
+        )
+
+    # Run Qt application event processing
+    sys.exit(qt_app.exec_())
+
+
+if __name__ == "__main__":
+    args = list(sys.argv)
+    if os.path.abspath(__file__) == os.path.normpath(args[0]):
+        # Pop path to script
+        args.pop(0)
+    main(args)

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -94,7 +94,9 @@ def export_model(current_file: str, fbx_filepath: str, xml_filepath: str):
 
         # Set FBX-specific options
         export_options.fbxCacheCompatible = True
-        export_options.fbxCacheFormat = SpeedTree.StpFbxCacheFormat.STP_FBX_CACHE_FORMAT_MCX
+        export_options.fbxCacheFormat = (
+            SpeedTree.StpFbxCacheFormat.STP_FBX_CACHE_FORMAT_MCX
+        )
         export_options.fbxAxis = SpeedTree.StpFbxAxis.STP_FBX_AXIS_MAYA_Y_UP
         export_options.fbxBonesSmooth = True
         # Set other export options

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -1,9 +1,22 @@
 import os
 import logging
 from . import CommunicationWrapper
+import ctypes
+import time
+import contextlib
 
 
 log = logging.getLogger("speedtree.lib")
+
+
+# Define necessary constants and structures
+user32 = ctypes.windll.user32
+kernel32 = ctypes.windll.kernel32
+
+VK_CONTROL = 0x11
+VK_S = 0x53
+KEYEVENTF_KEYUP = 0x0002
+SW_RESTORE = 9
 
 
 def get_workdir() -> str:
@@ -22,3 +35,64 @@ def execute_sptree_command(zscript, communicator=None):
         communicator = CommunicationWrapper.communicator
     print(f"Executing speedtree command: {zscript}")
     return communicator.execute_sptree_command(zscript)
+
+
+def _enum_windows_callback(hwnd, windows):
+    """Function to get the list of open windows for hacky way to
+    save file before passing to SDK to execute the action
+    Args:
+        hwnd (_type_): _description_
+        windows (_type_): _description_
+
+    Returns:
+        _type_: _description_
+    """
+    if user32.IsWindowVisible(hwnd) and user32.IsWindowEnabled(hwnd):
+        length = user32.GetWindowTextLengthW(hwnd)
+        buff = ctypes.create_unicode_buffer(length + 1)
+        user32.GetWindowTextW(hwnd, buff, length + 1)
+        windows.append((hwnd, buff.value))
+    return True
+
+
+def get_open_windows():
+    WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int))
+    enum_windows_callback_func = WNDENUMPROC(_enum_windows_callback)
+    windows = []
+    user32.EnumWindows(enum_windows_callback_func, ctypes.byref(ctypes.c_int(len(windows))))
+    return windows
+
+
+def save_file_with_hotkey():
+    """Function to save a file using a hotkey (Ctrl+S)
+
+    """
+    # Simulate pressing Ctrl+S
+    user32.keybd_event(VK_CONTROL, 0, 0, 0)
+    user32.keybd_event(VK_S, 0, 0, 0)
+    time.sleep(0.1)  # Small delay to ensure the key press is registered
+    user32.keybd_event(VK_S, 0, KEYEVENTF_KEYUP, 0)
+    user32.keybd_event(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0)
+
+
+@contextlib.contextmanager
+def set_focus_to_window(window_title):
+    """Function to save file before passing it into the headless SDR to publish or
+    increment and save file.
+
+    Args:
+        window_title (str, optional): Current Ayon tool windows.
+
+    """
+    prev_hwnd = user32.FindWindowW(None, window_title)
+    hwnd = user32.FindWindowW(None, "SpeedTree  Modeler 10.0.0 ")
+    if hwnd:
+        if user32.IsIconic(hwnd):
+            user32.ShowWindow(hwnd, SW_RESTORE)
+        user32.SetForegroundWindow(hwnd)
+        save_file_with_hotkey()
+    try:
+        yield
+    finally:
+        user32.ShowWindow(prev_hwnd, SW_RESTORE)
+

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -6,7 +6,6 @@ from . import CommunicationWrapper
 log = logging.getLogger("speedtree.lib")
 
 
-
 def get_workdir() -> str:
     """Return the currently active work directory"""
     return os.environ["AYON_WORKDIR"]

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -37,32 +37,6 @@ def execute_sptree_command(zscript, communicator=None):
     return communicator.execute_sptree_command(zscript)
 
 
-def _enum_windows_callback(hwnd, windows):
-    """Function to get the list of open windows for hacky way to
-    save file before passing to SDK to execute the action
-    Args:
-        hwnd (_type_): _description_
-        windows (_type_): _description_
-
-    Returns:
-        _type_: _description_
-    """
-    if user32.IsWindowVisible(hwnd) and user32.IsWindowEnabled(hwnd):
-        length = user32.GetWindowTextLengthW(hwnd)
-        buff = ctypes.create_unicode_buffer(length + 1)
-        user32.GetWindowTextW(hwnd, buff, length + 1)
-        windows.append((hwnd, buff.value))
-    return True
-
-
-def get_open_windows():
-    WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int))
-    enum_windows_callback_func = WNDENUMPROC(_enum_windows_callback)
-    windows = []
-    user32.EnumWindows(enum_windows_callback_func, ctypes.byref(ctypes.c_int(len(windows))))
-    return windows
-
-
 def save_file_with_hotkey():
     """Function to save a file using a hotkey (Ctrl+S)
 

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -110,3 +110,16 @@ def export_model(current_file: str, fbx_filepath: str, xml_filepath: str):
             log.debug("Successfully export tree model.")
 
     context.delete()
+
+
+def load_spm_file(spm_file, communicator=None):
+    """Load spm file for either loading existing file or refreshing purpose.
+    There is no way in SpeedTree to increment and save for current workfile.
+    Ayon needs to always save and re-load the spm file again for getting
+    the latest version.
+    """
+    if not communicator:
+        communicator = CommunicationWrapper.communicator
+    print(f"Loading Spm file: {spm_file}")
+    speedtree_executable = os.environ["SPTREE_EXE"]
+    return communicator.replace_process([speedtree_executable, spm_file])

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -5,6 +5,8 @@ import ctypes
 import time
 import contextlib
 
+import speedtree.SpeedTree as SpeedTree
+
 
 log = logging.getLogger("speedtree.lib")
 
@@ -37,7 +39,7 @@ def execute_sptree_command(zscript, communicator=None):
     return communicator.execute_sptree_command(zscript)
 
 
-def save_file_with_hotkey():
+def _save_file_with_hotkey():
     """Function to save a file using a hotkey (Ctrl+S)
 
     """
@@ -50,9 +52,9 @@ def save_file_with_hotkey():
 
 
 @contextlib.contextmanager
-def set_focus_to_window(window_title):
-    """Function to save file before passing it into the headless SDR to publish or
-    increment and save file.
+def save_scene(window_title):
+    """Hacky function to save file during context before passing
+    it into the headless SDR to publish or increment and save file
 
     Args:
         window_title (str, optional): Current Ayon tool windows.
@@ -64,9 +66,47 @@ def set_focus_to_window(window_title):
         if user32.IsIconic(hwnd):
             user32.ShowWindow(hwnd, SW_RESTORE)
         user32.SetForegroundWindow(hwnd)
-        save_file_with_hotkey()
+        _save_file_with_hotkey()
     try:
         yield
     finally:
         user32.ShowWindow(prev_hwnd, SW_RESTORE)
 
+
+def export_model(current_file: str, fbx_filepath: str, xml_filepath: str):
+    """Function to export model in fbx format along with the xml file.
+
+    Args:
+        current_file (str): current file
+        fbx_filepath (str): fbx output filepath
+        xml_filepath (str): xml output filepath
+    """
+    resource_path = os.path.dirname(os.path.dirname(os.environ["SPTREE_EXE"]))
+    resource_path = os.path.normpath(resource_path)
+    SpeedTree.StpSetExportResourcePath(resource_path)
+    context = SpeedTree.StpContext()
+    context.new()
+    loaded, _ = context.loadSpeedTreeFile(current_file)
+    if loaded:
+        # Configure FBX export options
+        export_options = SpeedTree.StpVfxExportOptions()
+        export_options.initVfxExportOptions()
+
+        # Set FBX-specific options
+        export_options.fbxCacheCompatible = True
+        export_options.fbxCacheFormat = SpeedTree.StpFbxCacheFormat.STP_FBX_CACHE_FORMAT_MCX
+        export_options.fbxAxis = SpeedTree.StpFbxAxis.STP_FBX_AXIS_MAYA_Y_UP
+        export_options.fbxBonesSmooth = True
+        # Set other export options
+        export_options.include3dGeometry = True
+        export_options.includeBones = True
+        export_options.animationWind = True
+        export_options.animationFPS = 30
+        export_options.textureSkipWriting = True
+        fbx_success = context.exportForVfx(fbx_filepath, export_options)
+        xml_success = context.exportForVfx(xml_filepath, export_options)
+        # Cleanup
+        if fbx_success and xml_success:
+            log.debug("Successfully export tree model.")
+
+    context.delete()

--- a/client/ayon_speedtree/api/lib.py
+++ b/client/ayon_speedtree/api/lib.py
@@ -1,0 +1,25 @@
+import os
+import logging
+from . import CommunicationWrapper
+
+
+log = logging.getLogger("speedtree.lib")
+
+
+
+def get_workdir() -> str:
+    """Return the currently active work directory"""
+    return os.environ["AYON_WORKDIR"]
+
+
+def execute_sptree_command(zscript, communicator=None):
+    """Execute Speedtree command.
+
+    Note that this will *not* wait around for the Speedtree command to run or
+    for its completion. Nor will errors in the script be detected or raised.
+
+    """
+    if not communicator:
+        communicator = CommunicationWrapper.communicator
+    print(f"Executing speedtree command: {zscript}")
+    return communicator.execute_sptree_command(zscript)

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -96,10 +96,7 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             content = str(current_file.read())
             filepath = content.rstrip('\x00')
             current_file.close()
-        if filepath is None:
-            filepath = os.environ["CURRENT_SPM"]
-
-        return filepath
+            return filepath
 
     def workfile_has_unsaved_changes(self):
         # Pop-up dialog would be located to ask if users
@@ -115,20 +112,14 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return filepath
 
     def save_workfile(self, filepath=None):
-        has_workfile = False
         if not filepath:
-            filepath = (
-                self.get_current_workfile()
-                or os.environ["CURRENT_SPM"]
-            )
-            has_workfile = True
+            filepath = self.get_current_workfile()
         with save_scene("Work Files"):
-            filepath, context = open_workfile(filepath)
+            context = open_workfile(filepath)
             filepath = save_workfile(filepath, context)
-        load_spm_file(filepath)
-        if has_workfile:
-            copy_ayon_data(filepath)
+        copy_ayon_data(filepath)
         set_current_file(filepath)
+        load_spm_file(filepath)
         return filepath
 
     def list_instances(self):
@@ -459,7 +450,11 @@ def set_current_file(filepath=None):
     if filepath is None:
         with open(txt_file, "w"):
             pass
-        return filepath
+    with open (txt_file, "w") as current_file:
+        current_file.write(filepath)
+        current_file.close()
+
+    return filepath
 
 
 def imprint(container, representation_id):
@@ -592,20 +587,19 @@ def show_tools_dialog():
 def open_workfile(filepath):
     context = SpeedTree.StpContext()
     context.new()
-
-    # Set maximum CPU threads
-    context.setMaxCpuThreads(4)
-
     # Load a SpeedTree file
+    if not os.path.exists(filepath):
+        filepath = os.environ["CURRENT_SPM"]
     loaded, _ = context.loadSpeedTreeFile(filepath)
     if loaded:
-        return filepath, context
-
-    return None, context
+        return context
+    return None
 
 
 def save_workfile(filepath, context):
     if filepath:
         options = SpeedTree.StpSaveSpmOptions()
         context.saveSpeedTreeFile(filepath, options)
+
+    context.delete()
     return filepath

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -43,10 +43,6 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         show_tools_dialog()
 
     def install(self):
-        # Create workdir folder if does not exist yet
-        workdir = os.getenv("AYON_WORKDIR")
-        if not os.path.exists(workdir):
-            os.makedirs(workdir)
 
         plugins_dir = os.path.join(SPTREE_ADDON_ROOT, "plugins")
         publish_dir = os.path.join(plugins_dir, "publish")
@@ -125,6 +121,23 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         copy_ayon_data(filepath)
         set_current_file(filepath)
         return filepath
+
+    def list_instances(self):
+        """Get all AYON instances."""
+        # Figure out how to deal with this
+        return get_instance_workfile_metadata()
+
+    def write_instances(self, data):
+        """Write all AYON instances"""
+        return write_workfile_metadata(SPTREE_SECTION_NAME_INSTANCES, data)
+
+    def get_containers(self):
+        """Get the data of the containers
+
+        Returns:
+            list: the list which stores the data of the containers
+        """
+        return get_containers()
 
     def initial_app_launch(self):
         """Triggers on launch of the communication server for Speedtree.
@@ -437,6 +450,37 @@ def set_current_file(filepath=None):
         with open(txt_file, "w"):
             pass
         return filepath
+
+
+def get_instance_workfile_metadata():
+    """Get instance data from the related metadata json("instances.json")
+    which stores in .sptree_metadata/{workfile}/instances folder
+    in the project work directory.
+
+    Instance data includes the info like the workfile instance
+    and any instances created by the users for publishing.
+
+    Returns:
+        dict: instance data
+    """
+    file_content = []
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata",
+        current_file, SPTREE_SECTION_NAME_INSTANCES).replace(
+            "\\", "/"
+        )
+    if not os.path.exists(json_dir) or not os.listdir(json_dir):
+        return file_content
+    for file in os.listdir(json_dir):
+        with open (f"{json_dir}/{file}", "r") as data:
+            file_content = json.load(data)
+
+    return file_content
 
 
 def remove_tmp_data():

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -1,0 +1,326 @@
+"""Pipeline tools for AYON Speedtree integration."""
+import os
+import ast
+import json
+import shutil
+import logging
+import tempfile
+import pyblish.api
+from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
+from ayon_core.pipeline import (
+    register_creator_plugin_path,
+    register_loader_plugin_path,
+    AYON_CONTAINER_ID,
+    registered_host
+)
+from ayon_core.pipeline.context_tools import get_global_context
+
+from ayon_core.settings import get_current_project_settings
+from ayon_core.lib import register_event_callback
+from ayon_core.tools.utils import host_tools
+from ayon_speedtree import SPTREE_ADDON_ROOT
+from .lib import get_workdir, execute_sptree_command
+
+import SpeedTree
+
+
+METADATA_SECTION = "avalon"
+SPTREE_SECTION_NAME_CONTEXT = "context"
+SPTREE_METADATA_CREATE_CONTEXT = "create_context"
+SPTREE_SECTION_NAME_INSTANCES = "instances"
+SPTREE_SECTION_NAME_CONTAINERS = "containers"
+
+
+log = logging.getLogger("ayon.hosts.speedtree")
+
+
+class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
+    name = "speedtree"
+
+    @staticmethod
+    def show_tools_dialog():
+        """Show tools dialog with actions leading to show other tools."""
+        show_tools_dialog()
+
+    def install(self):
+        # Create workdir folder if does not exist yet
+        workdir = os.getenv("AYON_WORKDIR")
+        if not os.path.exists(workdir):
+            os.makedirs(workdir)
+
+        plugins_dir = os.path.join(SPTREE_ADDON_ROOT, "plugins")
+        publish_dir = os.path.join(plugins_dir, "publish")
+        load_dir = os.path.join(plugins_dir, "load")
+        create_dir = os.path.join(plugins_dir, "create")
+
+        pyblish.api.register_host("speedtree")
+        pyblish.api.register_plugin_path(publish_dir)
+        register_loader_plugin_path(load_dir)
+        register_creator_plugin_path(create_dir)
+
+        register_event_callback("application.launched", self.initial_app_launch)
+
+    def get_current_project_name(self):
+        """
+        Returns:
+            Union[str, None]: Current project name.
+        """
+
+        return self.get_current_context().get("project_name")
+
+    def get_current_folder_path(self):
+        """
+        Returns:
+            Union[str, None]: Current folder path.
+        """
+
+        return self.get_current_context().get("folder_path")
+
+    def get_current_task_name(self):
+        """
+        Returns:
+            Union[str, None]: Current task name.
+        """
+
+        return self.get_current_context().get("task_name")
+
+    def get_current_context(self):
+        context = get_current_workfile_context()
+        if not context:
+            return get_global_context()
+        if "project_name" in context:
+            return context
+        # This is legacy way how context was stored
+        return {
+            "project_name": context.get("project_name"),
+            "folder_path": context.get("folder_path"),
+            "task_name": context.get("task_name")
+        }
+
+    def get_current_workfile(self):
+        work_dir = get_workdir()
+        txt_dir = os.path.join(
+            work_dir, ".sptree_metadata").replace(
+                "\\", "/"
+        )
+        with open (f"{txt_dir}/current_file.txt", "r") as current_file:
+            content = str(current_file.read())
+            filepath = content.rstrip('\x00')
+            current_file.close()
+            return filepath
+
+    def workfile_has_unsaved_changes(self):
+        # Pop-up dialog would be located to ask if users
+        # save scene if it has unsaved changes
+        return True
+
+    def get_workfile_extensions(self):
+        return [".spm"]
+
+    def open_workfile(self, filepath):
+        filepath, _ = open_workfile(filepath)
+        set_current_file(filepath=filepath)
+        return filepath
+
+    def save_workfile(self, filepath=None):
+        if not filepath:
+            filepath = self.get_current_workfile()
+        filepath, context = open_workfile(filepath)
+        options = SpeedTree.StpSaveSpmOptions()
+        saved = context.saveSpeedTreeFile(filepath, options)
+        if saved:
+            return filepath
+        return None
+
+    def initial_app_launch(self):
+        """Triggers on launch of the communication server for Zbrush.
+
+        Usually this aligns roughly with the start of Zbrush.
+        """
+        #TODO: figure out how to deal with the last workfile issue
+        set_current_file()
+        context = get_global_context()
+        save_current_workfile_context(context)
+
+
+def save_current_workfile_context(context):
+    """Save current workfile context data to `.sptree_metadata/{workfile}/key`
+
+    This persists the current in-memory context to be set for a specific
+    workfile on disk. Usually used on save to persist the local sessions'
+    workfile context on save.
+
+    The context data includes things like the project name, folder path,
+    etc.
+
+    Args:
+        context (dict): context data
+
+    """
+    return write_context_metadata(SPTREE_SECTION_NAME_CONTEXT, context)
+
+
+def write_context_metadata(metadata_key, context):
+    """Write context data into the related json
+    which stores in .sptree_metadata/key folder
+    in the project work directory.
+
+    The context data includes the project name, folder path
+    and task name.
+
+    Args:
+        metadata_key (str): metadata key
+        context (dict): context data
+    """
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".zbrush_metadata", metadata_key).replace(
+            "\\", "/"
+        )
+    os.makedirs(json_dir, exist_ok=True)
+    json_file = f"{json_dir}/{metadata_key}.json"
+    if os.path.exists(json_file):
+        with open (json_file, "r") as file:
+            value = json.load(file)
+            if value == context:
+                return
+    with open (json_file, "w") as file:
+        value = json.dumps(context)
+        file.write(value)
+        file.close()
+
+
+def get_current_workfile_context():
+    """Function to get the current context data from the related
+    json file in .sptree_metadata/context folder
+
+    The current context data includes thing like project name,
+    folder path and task name.
+
+    Returns:
+        list: list of context data
+    """
+    return get_load_context_metadata()
+
+
+def get_load_context_metadata():
+    """Get the context data from the related json file
+    ("context.json") which stores in .sptree_metadata/context
+    folder in the project work directory.
+
+    The context data includes the project name, folder path and
+    task name.
+
+    Returns:
+        list: context data
+    """
+    file_content = {}
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata", SPTREE_SECTION_NAME_CONTEXT).replace(
+            "\\", "/"
+        )
+    if not os.path.exists(json_dir):
+        return file_content
+    file_list = os.listdir(json_dir)
+    if not file_list:
+        return file_content
+    for file in file_list:
+        with open (f"{json_dir}/{file}", "r") as data:
+            content = ast.literal_eval(str(data.read().strip()))
+            file_content.update(content)
+            data.close()
+    return file_content
+
+
+
+def set_current_file(filepath=None):
+    """Function to store current workfile path
+
+    Args:
+        filepath (str, optional): current workfile path. Defaults to None.
+    """
+    work_dir = get_workdir()
+    txt_dir = os.path.join(
+        work_dir, ".sptree_metadata").replace(
+            "\\", "/"
+    )
+    os.makedirs(txt_dir, exist_ok=True)
+    txt_file = f"{txt_dir}/current_file.txt"
+    if filepath is None:
+        with open(txt_file, "w"):
+            pass
+        return filepath
+    filepath_check = tmp_current_file_check()
+    if filepath_check.endswith("spm"):
+        filepath = os.path.join(
+            os.path.dirname(filepath), filepath_check).replace("\\", "/")
+    with open (txt_file, "w") as current_file:
+        current_file.write(filepath)
+        current_file.close()
+
+
+def tmp_current_file_check():
+    """Function to find the latest .spm file used
+    by the user in Speedtree.
+
+    Returns:
+        file_content (str): the filepath in .spm format.
+            If the filepath does not end with '.spm' format,
+            it returns None.
+    """
+    output_file = tempfile.NamedTemporaryFile(
+        mode="w", prefix="a_sptree_cfc", suffix=".txt", delete=False
+    )
+    output_filepath = output_file.name.replace("\\", "/")
+    output_file.write(output_filepath)
+    output_file.close()
+    with open(output_filepath) as data:
+        file_content = str(data.read().strip()).rstrip('\x00')
+    os.remove(output_filepath)
+    return file_content
+
+
+def show_tools_dialog():
+    """Show dialog with tools.
+
+    Dialog will stay visible.
+    """
+    from ayon_speedtree.api import tools_ui
+
+    tools_ui.show_tools_dialog()
+
+
+def show_creator():
+    host_tools.show_creator()
+
+
+def show_loader():
+    host_tools.show_loader(use_context=True)
+
+
+def show_publisher():
+    host_tools.show_publish()
+
+
+def show_manager():
+    host_tools.show_scene_inventory()
+
+
+def show_workfiles():
+    host_tools.show_workfiles(use_context=True)
+
+
+def open_workfile(filepath):
+    context = SpeedTree.StpContext()
+    context.new()
+
+    # Set maximum CPU threads
+    context.setMaxCpuThreads(4)
+
+    # Load a SpeedTree file
+    loaded, _ = context.loadSpeedTreeFile(filepath)
+    if loaded:
+        return filepath, context
+
+    return None, context

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -17,7 +17,7 @@ from ayon_core.pipeline.context_tools import get_global_context
 from ayon_core.settings import get_current_project_settings
 from ayon_core.lib import register_event_callback
 from ayon_speedtree import SPTREE_ADDON_ROOT
-from .lib import get_workdir, set_focus_to_window
+from .lib import get_workdir, save_scene
 
 import speedtree.SpeedTree as SpeedTree
 
@@ -116,7 +116,7 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         if not filepath:
             filepath = self.get_current_workfile()
             has_workfile = True
-        with set_focus_to_window("Work Files"):
+        with save_scene("Work Files"):
             filepath, context = open_workfile(filepath)
             filepath = save_workfile(filepath, context)
         if has_workfile:

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -113,10 +113,10 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return filepath
 
     def save_workfile(self, filepath=None):
+        if not filepath:
+            filepath = self.get_current_workfile()
         with save_scene("Work Files"):
-            if not filepath:
-                filepath = self.get_current_workfile()
-            context = open_workfile(filepath)
+            context = open_workfile()
             filepath = save_workfile(filepath, context)
         copy_ayon_data(filepath)
         set_current_file(filepath)
@@ -586,12 +586,10 @@ def show_tools_dialog():
     tools_ui.show_tools_dialog()
 
 
-def open_workfile(filepath):
+def open_workfile():
     context = SpeedTree.StpContext()
     context.new()
-    # Load a SpeedTree file
-    if not os.path.exists(filepath):
-        filepath = os.environ["CURRENT_SPM"]
+    filepath = os.environ["CURRENT_SPM"]
     loaded, _ = context.loadSpeedTreeFile(filepath)
     if loaded:
         return context
@@ -602,6 +600,8 @@ def save_workfile(filepath, context):
     if filepath:
         options = SpeedTree.StpSaveSpmOptions()
         context.saveSpeedTreeFile(filepath, options)
+
+    os.environ["CURRENT_SPM"] = filepath
 
     context.delete()
     return filepath

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -112,9 +112,10 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return filepath
 
     def save_workfile(self, filepath=None):
-        if not filepath:
-            filepath = self.get_current_workfile()
         with save_scene("Work Files"):
+            if not filepath:
+                filepath = self.get_current_workfile()
+            # fix this
             context = open_workfile(filepath)
             filepath = save_workfile(filepath, context)
         copy_ayon_data(filepath)

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -88,16 +88,7 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return context
 
     def get_current_workfile(self):
-        work_dir = get_workdir()
-        txt_dir = os.path.join(
-            work_dir, ".sptree_metadata").replace(
-                "\\", "/"
-        )
-        with open (f"{txt_dir}/current_file.txt", "r") as current_file:
-            content = str(current_file.read())
-            filepath = content.rstrip('\x00')
-            current_file.close()
-            return filepath
+        return os.environ["CURRENT_SPM"]
 
     def workfile_has_unsaved_changes(self):
         # Pop-up dialog would be located to ask if users
@@ -109,17 +100,13 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def open_workfile(self, filepath):
         load_spm_file(filepath)
-        set_current_file(filepath=filepath)
         return filepath
 
     def save_workfile(self, filepath=None):
-        if not filepath:
-            filepath = self.get_current_workfile()
         with save_scene("Work Files"):
             context = open_workfile()
             filepath = save_workfile(filepath, context)
         copy_ayon_data(filepath)
-        set_current_file(filepath)
         load_spm_file(filepath)
         return filepath
 
@@ -145,9 +132,6 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         Usually this aligns roughly with the start of Speedtree.
         """
-        #TODO: figure out how to deal with the last workfile issue
-        current_file = os.environ["CURRENT_SPM"]
-        set_current_file(current_file)
         context = get_global_context()
         save_current_workfile_context(context)
         # Initialize the SpeedTree system
@@ -434,29 +418,6 @@ def get_load_workfile_metadata(metadata_key):
             file_content.extend(content)
             data.close()
     return file_content
-
-
-def set_current_file(filepath=None):
-    """Function to store current workfile path
-
-    Args:
-        filepath (str, optional): current workfile path. Defaults to None.
-    """
-    work_dir = get_workdir()
-    txt_dir = os.path.join(
-        work_dir, ".sptree_metadata").replace(
-            "\\", "/"
-    )
-    os.makedirs(txt_dir, exist_ok=True)
-    txt_file = f"{txt_dir}/current_file.txt"
-    if filepath is None:
-        with open(txt_file, "w"):
-            pass
-    with open (txt_file, "w") as current_file:
-        current_file.write(filepath)
-        current_file.close()
-
-    return filepath
 
 
 def imprint(container, representation_id):

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -21,7 +21,7 @@ from ayon_core.tools.utils import host_tools
 from ayon_speedtree import SPTREE_ADDON_ROOT
 from .lib import get_workdir, execute_sptree_command
 
-import SpeedTree
+import speedtree.SpeedTree as SpeedTree
 
 
 METADATA_SECTION = "avalon"
@@ -133,9 +133,9 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return None
 
     def initial_app_launch(self):
-        """Triggers on launch of the communication server for Zbrush.
+        """Triggers on launch of the communication server for Speedtree.
 
-        Usually this aligns roughly with the start of Zbrush.
+        Usually this aligns roughly with the start of Speedtree.
         """
         #TODO: figure out how to deal with the last workfile issue
         set_current_file()
@@ -174,7 +174,7 @@ def write_context_metadata(metadata_key, context):
     """
     work_dir = get_workdir()
     json_dir = os.path.join(
-        work_dir, ".zbrush_metadata", metadata_key).replace(
+        work_dir, ".sptree_metadata", metadata_key).replace(
             "\\", "/"
         )
     os.makedirs(json_dir, exist_ok=True)

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -99,14 +99,15 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return [".spm"]
 
     def open_workfile(self, filepath):
-        load_spm_file(filepath)
         os.environ["CURRENT_SPM"] = filepath
+        load_spm_file(filepath)
         return filepath
 
     def save_workfile(self, filepath=None):
         with save_scene("Work Files"):
             context = open_workfile()
             filepath = save_workfile(filepath, context)
+        print(f"Saving Spm file: {filepath}")
         copy_ayon_data(filepath)
         load_spm_file(filepath)
         return filepath

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -115,7 +115,6 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         with save_scene("Work Files"):
             if not filepath:
                 filepath = self.get_current_workfile()
-            # fix this
             context = open_workfile(filepath)
             filepath = save_workfile(filepath, context)
         copy_ayon_data(filepath)

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -17,7 +17,7 @@ from ayon_core.pipeline.context_tools import get_global_context
 from ayon_core.settings import get_current_project_settings
 from ayon_core.lib import register_event_callback
 from ayon_speedtree import SPTREE_ADDON_ROOT
-from .lib import get_workdir, save_scene
+from .lib import get_workdir, save_scene, load_spm_file
 
 import speedtree.SpeedTree as SpeedTree
 
@@ -96,7 +96,10 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             content = str(current_file.read())
             filepath = content.rstrip('\x00')
             current_file.close()
-            return filepath
+        if filepath is None:
+            filepath = os.environ["CURRENT_SPM"]
+
+        return filepath
 
     def workfile_has_unsaved_changes(self):
         # Pop-up dialog would be located to ask if users
@@ -107,18 +110,22 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return [".spm"]
 
     def open_workfile(self, filepath):
-        filepath, _ = open_workfile(filepath)
+        load_spm_file(filepath)
         set_current_file(filepath=filepath)
         return filepath
 
     def save_workfile(self, filepath=None):
         has_workfile = False
         if not filepath:
-            filepath = self.get_current_workfile()
+            filepath = (
+                self.get_current_workfile()
+                or os.environ["CURRENT_SPM"]
+            )
             has_workfile = True
         with save_scene("Work Files"):
             filepath, context = open_workfile(filepath)
             filepath = save_workfile(filepath, context)
+        load_spm_file(filepath)
         if has_workfile:
             copy_ayon_data(filepath)
         set_current_file(filepath)

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -100,6 +100,7 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def open_workfile(self, filepath):
         load_spm_file(filepath)
+        os.environ["CURRENT_SPM"] = filepath
         return filepath
 
     def save_workfile(self, filepath=None):

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -59,6 +59,7 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(create_dir)
 
         register_event_callback("application.launched", self.initial_app_launch)
+        register_event_callback("application.exit", self.application_exit)
 
     def get_current_project_name(self):
         """
@@ -88,14 +89,8 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         context = get_current_workfile_context()
         if not context:
             return get_global_context()
-        if "project_name" in context:
-            return context
-        # This is legacy way how context was stored
-        return {
-            "project_name": context.get("project_name"),
-            "folder_path": context.get("folder_path"),
-            "task_name": context.get("task_name")
-        }
+
+        return context
 
     def get_current_workfile(self):
         work_dir = get_workdir()
@@ -127,10 +122,8 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             filepath = self.get_current_workfile()
         filepath, context = open_workfile(filepath)
         options = SpeedTree.StpSaveSpmOptions()
-        saved = context.saveSpeedTreeFile(filepath, options)
-        if saved:
-            return filepath
-        return None
+        context.saveSpeedTreeFile(filepath, options)
+        return filepath
 
     def initial_app_launch(self):
         """Triggers on launch of the communication server for Speedtree.
@@ -141,6 +134,14 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         set_current_file()
         context = get_global_context()
         save_current_workfile_context(context)
+        # Initialize the SpeedTree system
+        SpeedTree.StpInit()
+
+    def application_exit(self):
+        """Event action when the application exit
+        """
+        remove_tmp_data()
+        SpeedTree.StpShutDown()
 
 
 def save_current_workfile_context(context):
@@ -233,7 +234,6 @@ def get_load_context_metadata():
     return file_content
 
 
-
 def set_current_file(filepath=None):
     """Function to store current workfile path
 
@@ -251,34 +251,28 @@ def set_current_file(filepath=None):
         with open(txt_file, "w"):
             pass
         return filepath
-    filepath_check = tmp_current_file_check()
-    if filepath_check.endswith("spm"):
-        filepath = os.path.join(
-            os.path.dirname(filepath), filepath_check).replace("\\", "/")
-    with open (txt_file, "w") as current_file:
-        current_file.write(filepath)
-        current_file.close()
 
 
-def tmp_current_file_check():
-    """Function to find the latest .spm file used
-    by the user in Speedtree.
+def remove_tmp_data():
+    """Remove all temporary data which is created by AYON without
+    saving changes when launching Zbrush without enabling `skip
+    opening last workfile`
 
-    Returns:
-        file_content (str): the filepath in .spm format.
-            If the filepath does not end with '.spm' format,
-            it returns None.
     """
-    output_file = tempfile.NamedTemporaryFile(
-        mode="w", prefix="a_sptree_cfc", suffix=".txt", delete=False
-    )
-    output_filepath = output_file.name.replace("\\", "/")
-    output_file.write(output_filepath)
-    output_file.close()
-    with open(output_filepath) as data:
-        file_content = str(data.read().strip()).rstrip('\x00')
-    os.remove(output_filepath)
-    return file_content
+    work_dir = get_workdir()
+    for name in [SPTREE_METADATA_CREATE_CONTEXT,
+                 SPTREE_SECTION_NAME_INSTANCES,
+                 SPTREE_SECTION_NAME_CONTAINERS]:
+        json_dir = os.path.join(
+            work_dir, ".sptree_metadata", name).replace(
+                "\\", "/"
+            )
+        if not os.path.exists(json_dir):
+            continue
+        all_fname_list = [jfile for jfile in os.listdir(json_dir)
+                          if jfile.endswith("json")]
+        for fname in all_fname_list:
+            os.remove(f"{json_dir}/{fname}")
 
 
 def show_tools_dialog():
@@ -289,26 +283,6 @@ def show_tools_dialog():
     from ayon_speedtree.api import tools_ui
 
     tools_ui.show_tools_dialog()
-
-
-def show_creator():
-    host_tools.show_creator()
-
-
-def show_loader():
-    host_tools.show_loader(use_context=True)
-
-
-def show_publisher():
-    host_tools.show_publish()
-
-
-def show_manager():
-    host_tools.show_scene_inventory()
-
-
-def show_workfiles():
-    host_tools.show_workfiles(use_context=True)
 
 
 def open_workfile(filepath):

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -4,7 +4,6 @@ import ast
 import json
 import shutil
 import logging
-import tempfile
 import pyblish.api
 from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
 from ayon_core.pipeline import (
@@ -17,9 +16,8 @@ from ayon_core.pipeline.context_tools import get_global_context
 
 from ayon_core.settings import get_current_project_settings
 from ayon_core.lib import register_event_callback
-from ayon_core.tools.utils import host_tools
 from ayon_speedtree import SPTREE_ADDON_ROOT
-from .lib import get_workdir, execute_sptree_command
+from .lib import get_workdir, set_focus_to_window
 
 import speedtree.SpeedTree as SpeedTree
 
@@ -118,8 +116,9 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         if not filepath:
             filepath = self.get_current_workfile()
             has_workfile = True
-        filepath, context = open_workfile(filepath)
-        filepath = save_workfile(filepath, context)
+        with set_focus_to_window("Work Files"):
+            filepath, context = open_workfile(filepath)
+            filepath = save_workfile(filepath, context)
         if has_workfile:
             copy_ayon_data(filepath)
         set_current_file(filepath)
@@ -455,6 +454,46 @@ def set_current_file(filepath=None):
         return filepath
 
 
+def imprint(container, representation_id):
+    """Function to update the container data from
+    the related json file in .sptree_metadata/{workfile}/container
+    when updating or switching asset(s)
+
+    Args:
+        container (str): container
+        representation_id (str): representation id
+    """
+    old_container_data = []
+    data = {}
+    name = container["objectName"]
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata",
+        current_file, SPTREE_SECTION_NAME_CONTAINERS).replace(
+            "\\", "/"
+        )
+    js_fname = next((jfile for jfile in os.listdir(json_dir)
+                     if jfile.endswith(f"{name}.json")), None)
+    if js_fname:
+        with open(f"{json_dir}/{js_fname}", "r") as file:
+            old_container_data = json.load(file)
+            print(f"data: {type(old_container_data)}")
+            file.close()
+
+        open(f"{json_dir}/{js_fname}", 'w').close()
+        for item in old_container_data:
+            item["representation"] = representation_id
+            data.update(item)
+        with open(f"{json_dir}/{js_fname}", "w") as file:
+            new_container_data = json.dumps([data])
+            file.write(new_container_data)
+            file.close()
+
+
 def get_instance_workfile_metadata():
     """Get instance data from the related metadata json("instances.json")
     which stores in .sptree_metadata/{workfile}/instances folder
@@ -486,9 +525,33 @@ def get_instance_workfile_metadata():
     return file_content
 
 
+def remove_container_data(name):
+    """Function to remove the specific container data from
+    {subset_name}.json in .sptree_metadata/{workfile}/containers folder
+
+    Args:
+        name (str): object name stored in the container
+    """
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata",
+        current_file, SPTREE_SECTION_NAME_CONTAINERS).replace(
+            "\\", "/"
+        )
+    all_fname_list = os.listdir(json_dir)
+    json_file = next((jfile for jfile in all_fname_list
+                               if jfile == f"{name}.json"), None)
+    if json_file:
+        os.remove(f"{json_dir}/{json_file}")
+
+
 def remove_tmp_data():
     """Remove all temporary data which is created by AYON without
-    saving changes when launching Zbrush without enabling `skip
+    saving changes when launching Speedtree without enabling `skip
     opening last workfile`
 
     """

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -121,8 +121,9 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         if not filepath:
             filepath = self.get_current_workfile()
         filepath, context = open_workfile(filepath)
-        options = SpeedTree.StpSaveSpmOptions()
-        context.saveSpeedTreeFile(filepath, options)
+        filepath = save_workfile(filepath, context)
+        copy_ayon_data(filepath)
+        set_current_file(filepath)
         return filepath
 
     def initial_app_launch(self):
@@ -143,6 +144,30 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         remove_tmp_data()
         SpeedTree.StpShutDown()
 
+    def update_context_data(self, data, changes):
+        return write_workfile_metadata(SPTREE_METADATA_CREATE_CONTEXT, data)
+
+    def get_context_data(self):
+        get_load_workfile_metadata(SPTREE_METADATA_CREATE_CONTEXT)
+
+
+def containerise(
+        name, context, namespace="", loader=None, containers=None):
+    data = {
+        "schema": "openpype:container-2.0",
+        "id": AYON_CONTAINER_ID,
+        "name": name,
+        "namespace": namespace,
+        "loader": str(loader),
+        "representation": str(context["representation"]["id"]),
+    }
+    if containers is None:
+        containers = get_containers()
+
+    containers.append(data)
+
+    write_load_metadata(containers)
+    return data
 
 def save_current_workfile_context(context):
     """Save current workfile context data to `.sptree_metadata/{workfile}/key`
@@ -191,6 +216,36 @@ def write_context_metadata(metadata_key, context):
         file.close()
 
 
+def write_workfile_metadata(metadata_key, data=None):
+    """Function to write workfile metadata(such as creator's context data
+    and instance data) in .sptree_metadata/{workfile}/{metadata_key} folder
+    This persists the current in-memory instance/creator's context data
+    to be set for a specific workfile on disk. Usually used on save to
+    persist updating instance data and context data used in publisher.
+
+    Args:
+        metadata_key (str): metadata key
+        data (list, optional): metadata. Defaults to None.
+    """
+    if data is None:
+        data = []
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata",
+        current_file, metadata_key).replace(
+            "\\", "/"
+        )
+    os.makedirs(json_dir, exist_ok=True)
+    with open (f"{json_dir}/{metadata_key}.json", "w") as file:
+        value = json.dumps(data)
+        file.write(value)
+        file.close()
+
+
 def get_current_workfile_context():
     """Function to get the current context data from the related
     json file in .sptree_metadata/context folder
@@ -202,6 +257,95 @@ def get_current_workfile_context():
         list: list of context data
     """
     return get_load_context_metadata()
+
+
+def get_containers():
+    """Function to get the container data
+
+    Returns:
+        list: list of container data
+    """
+    output = get_load_workfile_metadata(SPTREE_SECTION_NAME_CONTAINERS)
+    if output:
+        for item in output:
+            if "objectName" not in item and "name" in item:
+                members = item["name"]
+                if isinstance(members, list):
+                    members = "|".join([str(member) for member in members])
+                item["objectName"] = members
+
+    return output
+
+
+def write_load_metadata(data):
+    """Write/Edit the container data into the related json file("{subset_name}.json")
+    which stores in .sptree_metadata/{workfile}/containers folder.
+    This persists the current in-memory containers data
+    to be set for updating and switching assets in scene inventory.
+
+    Args:
+        metadata_key (str): metadata key for container
+        data (list): list of container data
+    """
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    name = next((d["name"] for d in data), None)
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata",
+        current_file, SPTREE_SECTION_NAME_CONTAINERS).replace(
+            "\\", "/"
+        )
+    os.makedirs(json_dir, exist_ok=True)
+    json_file = f"{json_dir}/{name}.json"
+    if os.path.exists(json_file):
+        with open(json_file, "w"):
+            pass
+
+    with open(json_file, "w") as file:
+        value = json.dumps(data)
+        file.write(value)
+        file.close()
+
+
+def copy_ayon_data(filepath):
+    """Copy any ayon-related data(
+        such as instances, create-context, cotnainers)
+        from the previous workfile to the new one
+        when incrementing and saving workfile.
+
+    Args:
+        filepath (str): the workfile path to be saved
+    """
+    filename = os.path.splitext(os.path.basename(filepath))[0].strip()
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    for name in [SPTREE_METADATA_CREATE_CONTEXT,
+                 SPTREE_SECTION_NAME_INSTANCES,
+                 SPTREE_SECTION_NAME_CONTAINERS]:
+        src_json_dir = os.path.join(
+            work_dir, ".sptree_metadata", current_file, name).replace(
+                "\\", "/"
+            )
+        if not os.path.exists(src_json_dir):
+            continue
+        dst_json_dir = os.path.join(
+            work_dir, ".sptree_metadata", filename, name).replace(
+                "\\", "/"
+            )
+        os.makedirs(dst_json_dir, exist_ok=True)
+        all_fname_list = [jfile for jfile in os.listdir(src_json_dir)
+                        if jfile.endswith("json")]
+        if all_fname_list:
+            for fname in all_fname_list:
+                src_json = f"{src_json_dir}/{fname}"
+                dst_json = f"{dst_json_dir}/{fname}"
+                shutil.copy(src_json, dst_json)
 
 
 def get_load_context_metadata():
@@ -230,6 +374,48 @@ def get_load_context_metadata():
         with open (f"{json_dir}/{file}", "r") as data:
             content = ast.literal_eval(str(data.read().strip()))
             file_content.update(content)
+            data.close()
+    return file_content
+
+
+def get_load_workfile_metadata(metadata_key):
+    """Get to load the workfile json metadata(such as
+    creator's context data and container data) which stores in
+    .sptree_metadata/{workfile}/{metadata_key} folder in the project
+    work directory.
+    It mainly supports to the metadata_key below:
+    SPTREE_METADATA_CREATE_CONTEXT: loading create_context.json where
+        stores the data with publish_attributes(e.g. whether the
+        optional validator is enabled.)
+    SPTREE_SECTION_NAME_CONTAINERS: loading {subset_name}.json where
+        includes all the loaded asset data to the zbrush scene.
+
+    Args:
+        metadata_key (str): name of the metadata key
+
+    Returns:
+        list: list of metadata(create-context data or container data)
+    """
+    file_content = []
+    current_file = registered_host().get_current_workfile()
+    if current_file:
+        current_file = os.path.splitext(
+            os.path.basename(current_file))[0].strip()
+    work_dir = get_workdir()
+    json_dir = os.path.join(
+        work_dir, ".sptree_metadata",
+        current_file, metadata_key).replace(
+            "\\", "/"
+        )
+    if not os.path.exists(json_dir):
+        return file_content
+    file_list = os.listdir(json_dir)
+    if not file_list:
+        return file_content
+    for file in file_list:
+        with open (f"{json_dir}/{file}", "r") as data:
+            content = json.load(data)
+            file_content.extend(content)
             data.close()
     return file_content
 
@@ -298,3 +484,10 @@ def open_workfile(filepath):
         return filepath, context
 
     return None, context
+
+
+def save_workfile(filepath, context):
+    if filepath:
+        options = SpeedTree.StpSaveSpmOptions()
+        context.saveSpeedTreeFile(filepath, options)
+    return filepath

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -114,11 +114,14 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return filepath
 
     def save_workfile(self, filepath=None):
+        has_workfile = False
         if not filepath:
             filepath = self.get_current_workfile()
+            has_workfile = True
         filepath, context = open_workfile(filepath)
         filepath = save_workfile(filepath, context)
-        copy_ayon_data(filepath)
+        if has_workfile:
+            copy_ayon_data(filepath)
         set_current_file(filepath)
         return filepath
 
@@ -167,7 +170,7 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 def containerise(
         name, context, namespace="", loader=None, containers=None):
     data = {
-        "schema": "openpype:container-2.0",
+        "schema": "ayon:container-2.0",
         "id": AYON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -14,7 +14,6 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.context_tools import get_global_context
 
-from ayon_core.settings import get_current_project_settings
 from ayon_core.lib import register_event_callback
 from ayon_speedtree import SPTREE_ADDON_ROOT
 from .lib import get_workdir, save_scene, load_spm_file
@@ -52,7 +51,9 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_loader_plugin_path(load_dir)
         register_creator_plugin_path(create_dir)
 
-        register_event_callback("application.launched", self.initial_app_launch)
+        register_event_callback(
+            "application.launched", self.initial_app_launch
+        )
         register_event_callback("application.exit", self.application_exit)
 
     def get_current_project_name(self):
@@ -292,7 +293,8 @@ def get_containers():
 
 
 def write_load_metadata(data):
-    """Write/Edit the container data into the related json file("{subset_name}.json")
+    """Write/Edit the container data into the related json file
+    ("{subset_name}.json")
     which stores in .sptree_metadata/{workfile}/containers folder.
     This persists the current in-memory containers data
     to be set for updating and switching assets in scene inventory.

--- a/client/ayon_speedtree/api/pipeline.py
+++ b/client/ayon_speedtree/api/pipeline.py
@@ -147,7 +147,8 @@ class SpeedtreeHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         Usually this aligns roughly with the start of Speedtree.
         """
         #TODO: figure out how to deal with the last workfile issue
-        set_current_file()
+        current_file = os.environ["CURRENT_SPM"]
+        set_current_file(current_file)
         context = get_global_context()
         save_current_workfile_context(context)
         # Initialize the SpeedTree system

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -1,0 +1,103 @@
+from ayon_core.pipeline import CreatedInstance, Creator, AutoCreator
+from ayon_core.pipeline.create.creator_plugins import cache_and_get_instances
+
+SHARED_DATA_KEY = "ayon.Speedtree.instances"
+
+
+class SpeedtreeCreatorBase:
+    def _cache_and_get_instances(self):
+        return cache_and_get_instances(
+            self, SHARED_DATA_KEY, self.host.list_instances
+        )
+
+    def _update_instances(self, update_list):
+        if not update_list:
+            return
+        current_instances = self.host.list_instances()
+        cur_instances_by_id = {}
+        for instance_data in current_instances:
+            instance_id = instance_data.get("instance_id")
+            if instance_id:
+                cur_instances_by_id[instance_id] = instance_data
+
+        for instance, changes in update_list:
+            instance_data = changes.new_value
+            cur_instance_data = cur_instances_by_id.get(instance.id)
+            if cur_instance_data is None:
+                current_instances.append(instance_data)
+                continue
+            for key in set(cur_instance_data) - set(instance_data):
+                cur_instance_data.pop(key)
+            cur_instance_data.update(instance_data)
+        self.host.write_instances(current_instances)
+
+    def _collect_instances(self):
+        instances_by_identifier = self._cache_and_get_instances()
+        for instance_data in instances_by_identifier[self.identifier]:
+            instance = CreatedInstance.from_existing(instance_data, self)
+            self._add_instance_to_context(instance)
+
+
+class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
+    def create(self, product_name, instance_data, pre_create_data):
+        # TODO: use selection
+        new_instance = CreatedInstance(
+        self.product_type,
+        product_name,
+        instance_data,
+        self
+    )
+        self._store_new_instance(new_instance)
+
+    def collect_instances(self):
+        self._collect_instances()
+
+    def update_instances(self, update_list):
+        self._update_instances(update_list)
+
+    def remove_instances(self, instances):
+        ids_to_remove = {
+            instance.id
+            for instance in instances
+        }
+        cur_instances = self.host.list_instances()
+        changed = False
+        new_instances = []
+        for instance_data in cur_instances:
+            if instance_data.get("instance_id") in ids_to_remove:
+                changed = True
+            else:
+                new_instances.append(instance_data)
+
+        if changed:
+            self.host.write_instances(new_instances)
+
+        for instance in instances:
+            self._remove_instance_from_context(instance)
+
+    # Helper methods (this might get moved into Creator class)
+    def get_dynamic_data(self, *args, **kwargs):
+        # Change asset and name by current workfile context
+        create_context = self.create_context
+        asset_name = create_context.get_current_folder_path()
+        task_name = create_context.get_current_task_name()
+        output = {}
+        if asset_name:
+            output["asset"] = asset_name
+            if task_name:
+                output["task"] = task_name
+        return output
+
+    def _store_new_instance(self, new_instance):
+        instances_data = self.host.list_instances()
+        instances_data.append(new_instance.data_to_store())
+        self.host.write_instances(instances_data)
+        self._add_instance_to_context(new_instance)
+
+
+class SpeedTreeAutoCreator(AutoCreator, SpeedtreeCreatorBase):
+    def collect_instances(self):
+        self._collect_instances()
+
+    def update_instances(self, update_list):
+        self._update_instances(update_list)

--- a/client/ayon_speedtree/api/sdk/README.md
+++ b/client/ayon_speedtree/api/sdk/README.md
@@ -1,0 +1,3 @@
+# Directory for SpeedTree Pipeline Python Binding
+
+Please copy the speedtree folder from `{YOUR SPEEDTREE PIPELINE SDK DIRECTORY}\bindings\python\python3.9` to here

--- a/client/ayon_speedtree/api/tools_ui.py
+++ b/client/ayon_speedtree/api/tools_ui.py
@@ -63,7 +63,7 @@ class ToolsDialog(QtWidgets.QDialog):
             QtCore.Qt.Window
             | QtCore.Qt.WindowStaysOnTopHint
             | QtCore.Qt.WindowMinimizeButtonHint
-	        | QtCore.Qt.WindowMaximizeButtonHint
+            | QtCore.Qt.WindowMaximizeButtonHint
         )
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
 

--- a/client/ayon_speedtree/api/tools_ui.py
+++ b/client/ayon_speedtree/api/tools_ui.py
@@ -16,14 +16,14 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(ToolsBtnsWidget, self).__init__(parent)
 
-        # load_btn = QtWidgets.QPushButton("Load...", self)
+        load_btn = QtWidgets.QPushButton("Load...", self)
         # manage_btn = QtWidgets.QPushButton("Manage...", self)
         publish_btn = QtWidgets.QPushButton("Publish...", self)
         workfile_btn = QtWidgets.QPushButton("Workfile...", self)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        # layout.addWidget(load_btn, 0)
+        layout.addWidget(load_btn, 0)
         # layout.addWidget(manage_btn, 0)
         layout.addWidget(publish_btn, 0)
         layout.addWidget(workfile_btn , 0)

--- a/client/ayon_speedtree/api/tools_ui.py
+++ b/client/ayon_speedtree/api/tools_ui.py
@@ -29,7 +29,7 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
         layout.addWidget(workfile_btn , 0)
         layout.addStretch(1)
 
-        # load_btn.clicked.connect(self._on_load)
+        load_btn.clicked.connect(self._on_load)
         # manage_btn.clicked.connect(self._on_manage)
         publish_btn.clicked.connect(self._on_publish)
         workfile_btn.clicked.connect(self._on_workfile)

--- a/client/ayon_speedtree/api/tools_ui.py
+++ b/client/ayon_speedtree/api/tools_ui.py
@@ -62,6 +62,8 @@ class ToolsDialog(QtWidgets.QDialog):
         self.setWindowFlags(
             QtCore.Qt.Window
             | QtCore.Qt.WindowStaysOnTopHint
+            | QtCore.Qt.WindowMinimizeButtonHint
+	        | QtCore.Qt.WindowMaximizeButtonHint
         )
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
 

--- a/client/ayon_speedtree/api/tools_ui.py
+++ b/client/ayon_speedtree/api/tools_ui.py
@@ -16,21 +16,21 @@ class ToolsBtnsWidget(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(ToolsBtnsWidget, self).__init__(parent)
 
-        load_btn = QtWidgets.QPushButton("Load...", self)
+        # load_btn = QtWidgets.QPushButton("Load...", self)
+        # manage_btn = QtWidgets.QPushButton("Manage...", self)
         publish_btn = QtWidgets.QPushButton("Publish...", self)
-        manage_btn = QtWidgets.QPushButton("Manage...", self)
         workfile_btn = QtWidgets.QPushButton("Workfile...", self)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(load_btn, 0)
-        layout.addWidget(manage_btn, 0)
+        # layout.addWidget(load_btn, 0)
+        # layout.addWidget(manage_btn, 0)
         layout.addWidget(publish_btn, 0)
         layout.addWidget(workfile_btn , 0)
         layout.addStretch(1)
 
-        load_btn.clicked.connect(self._on_load)
-        manage_btn.clicked.connect(self._on_manage)
+        # load_btn.clicked.connect(self._on_load)
+        # manage_btn.clicked.connect(self._on_manage)
         publish_btn.clicked.connect(self._on_publish)
         workfile_btn.clicked.connect(self._on_workfile)
 

--- a/client/ayon_speedtree/api/tools_ui.py
+++ b/client/ayon_speedtree/api/tools_ui.py
@@ -1,0 +1,111 @@
+from qtpy import QtWidgets, QtCore, QtGui
+
+from ayon_core import (
+    resources,
+    style
+)
+from ayon_core.tools.utils.lib import qt_app_context
+from ayon_core.tools.utils import host_tools
+
+
+
+class ToolsBtnsWidget(QtWidgets.QWidget):
+    """Widget containing buttons which are clickable."""
+    tool_required = QtCore.Signal(str)
+
+    def __init__(self, parent=None):
+        super(ToolsBtnsWidget, self).__init__(parent)
+
+        load_btn = QtWidgets.QPushButton("Load...", self)
+        publish_btn = QtWidgets.QPushButton("Publish...", self)
+        manage_btn = QtWidgets.QPushButton("Manage...", self)
+        workfile_btn = QtWidgets.QPushButton("Workfile...", self)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(load_btn, 0)
+        layout.addWidget(manage_btn, 0)
+        layout.addWidget(publish_btn, 0)
+        layout.addWidget(workfile_btn , 0)
+        layout.addStretch(1)
+
+        load_btn.clicked.connect(self._on_load)
+        manage_btn.clicked.connect(self._on_manage)
+        publish_btn.clicked.connect(self._on_publish)
+        workfile_btn.clicked.connect(self._on_workfile)
+
+    def _on_create(self):
+        self.tool_required.emit("creator")
+
+    def _on_load(self):
+        self.tool_required.emit("loader")
+
+    def _on_publish(self):
+        self.tool_required.emit("publisher")
+
+    def _on_manage(self):
+        self.tool_required.emit("sceneinventory")
+
+    def _on_workfile(self):
+        self.tool_required.emit("workfiles")
+
+
+class ToolsDialog(QtWidgets.QDialog):
+    """Dialog with tool buttons that will stay opened until user close it."""
+    def __init__(self, *args, **kwargs):
+        super(ToolsDialog, self).__init__(*args, **kwargs)
+
+        self.setWindowTitle("Ayon tools")
+        icon = QtGui.QIcon(resources.get_ayon_icon_filepath())
+        self.setWindowIcon(icon)
+
+        self.setWindowFlags(
+            QtCore.Qt.Window
+            | QtCore.Qt.WindowStaysOnTopHint
+        )
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+        tools_widget = ToolsBtnsWidget(self)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(tools_widget)
+
+        tools_widget.tool_required.connect(self._on_tool_require)
+        self._tools_widget = tools_widget
+
+        self._first_show = True
+
+    def sizeHint(self):
+        result = super(ToolsDialog, self).sizeHint()
+        result.setWidth(result.width() * 2)
+        return result
+
+    def showEvent(self, event):
+        super(ToolsDialog, self).showEvent(event)
+        if self._first_show:
+            self.setStyleSheet(style.load_stylesheet())
+            self._first_show = False
+
+    def _on_tool_require(self, tool_name):
+        host_tools.show_tool_by_name(tool_name, parent=self)
+
+
+class WindowCache:
+    """Cached objects and methods to be used in global scope."""
+    _dialog = None
+    _popup = None
+    _first_show = True
+
+    @classmethod
+    def show_dialog(cls):
+        with qt_app_context():
+            if cls._dialog is None:
+                cls._dialog = ToolsDialog()
+
+            cls._dialog.show()
+            cls._dialog.raise_()
+            cls._dialog.activateWindow()
+
+
+def show_tools_dialog():
+    WindowCache.show_dialog()

--- a/client/ayon_speedtree/hooks/ayon_start_up_script.py
+++ b/client/ayon_speedtree/hooks/ayon_start_up_script.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Pre-launch to force speedtree startup script."""
-import os
 from ayon_speedtree import get_launch_script_path
 from ayon_core.lib import get_ayon_launcher_args
 from ayon_applications import PreLaunchHook, LaunchTypes

--- a/client/ayon_speedtree/hooks/ayon_start_up_script.py
+++ b/client/ayon_speedtree/hooks/ayon_start_up_script.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Pre-launch to force speedtree startup script."""
+from ayon_speedtree import get_launch_script_path
+from ayon_core.lib import get_ayon_launcher_args
+from ayon_applications import PreLaunchHook, LaunchTypes
+
+
+class SpeedtreeStartupScript(PreLaunchHook):
+    """Inject AYON plugins to SpeedTree.
+
+    Note that this works in combination whit Speedtree startup script that
+    is creating the environment variable for the AYON Plugin
+
+    Hook `GlobalHostDataHook` must be executed before this hook.
+    """
+    app_groups = {"speedtree"}
+    order = 9
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        executable_path = self.launch_context.launch_args.pop(0)
+        self.launch_context.env["SPTREE_EXE"] = executable_path
+        # Pop rest of launch arguments - There should not be other arguments!
+        remainders = []
+        new_launch_args = get_ayon_launcher_args(
+            "run", get_launch_script_path(), executable_path
+        )
+        # Append as whole list as these arguments should not be separated
+        self.launch_context.launch_args.append(new_launch_args)
+
+        if remainders:
+            self.log.warning((
+                "There are unexpected launch arguments in Speedtree launch. {}"
+            ).format(str(remainders)))
+            self.launch_context.launch_args.extend(remainders)

--- a/client/ayon_speedtree/hooks/ayon_start_up_script.py
+++ b/client/ayon_speedtree/hooks/ayon_start_up_script.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Pre-launch to force speedtree startup script."""
+import os
 from ayon_speedtree import get_launch_script_path
 from ayon_core.lib import get_ayon_launcher_args
 from ayon_applications import PreLaunchHook, LaunchTypes
@@ -14,7 +15,7 @@ class SpeedtreeStartupScript(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = {"speedtree"}
-    order = 9
+    order = 10
     launch_types = {LaunchTypes.local}
 
     def execute(self):

--- a/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
+++ b/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Pre-launch to copy SpeedTree Python Binding Script."""
+import os
+import shutil
+from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_speedtree import SPTREE_ADDON_ROOT
+
+
+class SpeedtreeStartupScript(PreLaunchHook):
+    """Copy Python Binding Folder from SpeedTree Pipeline SDK to
+    the sdk folder, and so that the addon can get the correct
+    PYTHONPATH to run the script.
+    """
+    app_groups = {"speedtree"}
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        speedtree_settings = self.data["project_settings"]["speedtree"]
+        sdk_folder = speedtree_settings["sdk_directory"]
+        if not sdk_folder and not os.path.exists(sdk_folder):
+            raise RuntimeError(
+                "Directory not found. Fail to copy the "
+                "SDK python binding folder.")
+        dst_folder = os.path.join(
+            SPTREE_ADDON_ROOT, "api", "sdk", "speedtree"
+        )
+        if os.path.exists(dst_folder):
+            self.log.info(
+                "SpeedTree Python Binding Folder is already copied."
+            )
+            return
+
+        shutil.copytree(sdk_folder, dst_folder)
+        self.log.info(
+            "SpeedTree Python binding folder "
+            f"copied from {sdk_folder} to {dst_folder}"
+        )

--- a/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
+++ b/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
@@ -16,7 +16,9 @@ class SpeedtreeStartupScript(PreLaunchHook):
 
     def execute(self):
         speedtree_settings = self.data["project_settings"]["speedtree"]
-        sdk_folder = speedtree_settings["sdk_directory"]
+        sdk_folder = os.path.normpath(
+            speedtree_settings["sdk_directory"]
+        )
         if not sdk_folder and not os.path.exists(sdk_folder):
             raise RuntimeError(
                 "Directory not found. Fail to copy the "

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -18,8 +18,10 @@ class CreateTempSpmFile(PreLaunchHook):
 
     def execute(self):
         last_workfile = self.data.get("last_workfile_path")
-        if self.data.get("start_last_workfile") and last_workfile:
-            self.log.info("It is set to not start last workfile on start.")
+        if self.data.get("start_last_workfile")  \
+            and last_workfile  \
+                and os.path.exists(last_workfile):
+            self.log.info("It is set to start last workfile on start.")
         else:
             executable_path = self.launch_context.env["SPTREE_EXE"]
             template_directory = os.path.dirname(os.path.dirname(executable_path))
@@ -33,7 +35,8 @@ class CreateTempSpmFile(PreLaunchHook):
                 template_directory, f"tree_templates/Games/{spm_filename}")
             last_workfile = os.path.join(staging_dir, spm_filename)
             shutil.copyfile(source_template_file, last_workfile)
-            self.launch_context.launch_args.append(last_workfile)
+
+        self.launch_context.launch_args.append(last_workfile)
 
         self.launch_context.env["CURRENT_SPM"] = last_workfile
 

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -1,0 +1,23 @@
+import os
+from ayon_applications import PreLaunchHook, LaunchTypes
+
+
+class CreateTempSpmFile(PreLaunchHook):
+    """Create Temp Spm File to SpeedTree.
+
+    The temp spm file would be created in SpeedTree prior to 
+    the launch of the software if there is no last workfile
+
+    Hook `GlobalHostDataHook` must be executed before this hook.
+    """
+    app_groups = {"speedtree"}
+    order = 10
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        last_workfile = self.data.get("last_workfile_path")
+        if not self.data.get("start_last_workfile") or \
+            not last_workfile or \
+                not os.path.exists(last_workfile):
+            self.log.info("It is set to not start last workfile on start.")
+            return

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -7,7 +7,7 @@ from ayon_core.pipeline import tempdir
 class CreateTempSpmFile(PreLaunchHook):
     """Create Temp Spm File to SpeedTree.
 
-    The temp spm file would be created in SpeedTree prior to 
+    The temp spm file would be created in SpeedTree prior to
     the launch of the software if there is no last workfile
 
     Hook `GlobalHostDataHook` must be executed before this hook.
@@ -24,12 +24,15 @@ class CreateTempSpmFile(PreLaunchHook):
             self.log.info("It is set to start last workfile on start.")
         else:
             executable_path = self.launch_context.env["SPTREE_EXE"]
-            template_directory = os.path.dirname(os.path.dirname(executable_path))
+            template_directory = os.path.dirname(
+                os.path.dirname(executable_path)
+            )
             staging_dir = tempdir.get_temp_dir(
                 self.data["project_name"],
                 use_local_temp=True
             )
-            # TODO: we can allow users to use their custom templates by task type.
+            # TODO: we can allow users to use their custom
+            # templates by task type.
             spm_filename = "Blank.spm"
             source_template_file = os.path.join(
                 template_directory, f"tree_templates/Games/{spm_filename}")

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -27,9 +27,11 @@ class CreateTempSpmFile(PreLaunchHook):
                 self.data["project_name"],
                 use_local_temp=True
             )
+            # TODO: we can allow users to use their custom templates by task type.
+            spm_filename = "Blank.spm"
             source_template_file = os.path.join(
-                template_directory, "tree_templates/Games/Blank.spm")
-            last_workfile = os.path.join(staging_dir, "Blank.spm")
+                template_directory, f"tree_templates/Games/{spm_filename}")
+            last_workfile = os.path.join(staging_dir, spm_filename)
             shutil.copyfile(source_template_file, last_workfile)
             self.launch_context.launch_args.append(last_workfile)
 

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -23,19 +23,12 @@ class CreateTempSpmFile(PreLaunchHook):
                 and os.path.exists(last_workfile):
             self.log.info("It is set to start last workfile on start.")
         else:
-            executable_path = self.launch_context.env["SPTREE_EXE"]
-            template_directory = os.path.dirname(
-                os.path.dirname(executable_path)
-            )
+            source_template_file = self.get_custom_template_path()
             staging_dir = tempdir.get_temp_dir(
                 self.data["project_name"],
                 use_local_temp=True
             )
-            # TODO: we can allow users to use their custom
-            # templates by task type.
-            spm_filename = "Blank.spm"
-            source_template_file = os.path.join(
-                template_directory, f"tree_templates/Games/{spm_filename}")
+            spm_filename = os.path.basename(source_template_file)
             last_workfile = os.path.join(staging_dir, spm_filename)
             shutil.copyfile(source_template_file, last_workfile)
 
@@ -43,3 +36,16 @@ class CreateTempSpmFile(PreLaunchHook):
 
         self.launch_context.env["CURRENT_SPM"] = last_workfile
 
+    def get_custom_template_path(self):
+        speedtree_settings = self.data["project_settings"]["speedtree"]
+        template_path = speedtree_settings["template_path"]
+        if template_path and os.path.exists(template_path):
+            return template_path
+        executable_path = self.launch_context.env["SPTREE_EXE"]
+        template_directory = os.path.dirname(
+            os.path.dirname(executable_path)
+        )
+        template_path = os.path.join(
+            template_directory, "tree_templates/Games/Blank.spm")
+
+        return template_path

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_core.pipeline import tempdir
 
 
 class CreateTempSpmFile(PreLaunchHook):
@@ -11,13 +13,25 @@ class CreateTempSpmFile(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = {"speedtree"}
-    order = 10
+    order = 12
     launch_types = {LaunchTypes.local}
 
     def execute(self):
         last_workfile = self.data.get("last_workfile_path")
-        if not self.data.get("start_last_workfile") or \
-            not last_workfile or \
-                not os.path.exists(last_workfile):
+        if self.data.get("start_last_workfile") and last_workfile:
             self.log.info("It is set to not start last workfile on start.")
-            return
+        else:
+            executable_path = self.launch_context.env["SPTREE_EXE"]
+            template_directory = os.path.dirname(os.path.dirname(executable_path))
+            staging_dir = tempdir.get_temp_dir(
+                self.data["project_name"],
+                use_local_temp=True
+            )
+            source_template_file = os.path.join(
+                template_directory, "tree_templates/Games/Blank.spm")
+            last_workfile = os.path.join(staging_dir, "Blank.spm")
+            shutil.copyfile(source_template_file, last_workfile)
+            self.launch_context.launch_args.append(last_workfile)
+
+        self.launch_context.env["CURRENT_SPM"] = last_workfile
+

--- a/client/ayon_speedtree/hooks/pre_subprocess_no_window.py
+++ b/client/ayon_speedtree/hooks/pre_subprocess_no_window.py
@@ -1,0 +1,21 @@
+import subprocess
+from ayon_applications import PreLaunchHook, LaunchTypes
+
+
+class LaunchServerNoWindow(PreLaunchHook):
+    """Specifically for Zbrush to make the AYON tools launching faster
+    """
+
+    # Should be as last hook because must change launch arguments to string
+    order = 1000
+    app_groups = {"speedtree"}
+    platforms = {"windows"}
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+
+        self.launch_context.kwargs.update({
+            "creationflags": subprocess.CREATE_NEW_CONSOLE,
+            "stdout": None,
+            "stderr": None
+        })

--- a/client/ayon_speedtree/plugins/create/create_model.py
+++ b/client/ayon_speedtree/plugins/create/create_model.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""Creator plugin for model."""
+from ayon_speedtree.api import plugin
+
+
+class CreateModel(plugin.SpeedTreeCreator):
+    """Creator plugin for Model."""
+    identifier = "io.ayon.creators.speedtree.model"
+    label = "Model"
+    product_type = "model"
+    icon = "cube"

--- a/client/ayon_speedtree/plugins/create/create_workfile.py
+++ b/client/ayon_speedtree/plugins/create/create_workfile.py
@@ -4,7 +4,7 @@ import ayon_api
 from ayon_core.pipeline import CreatedInstance
 from ayon_speedtree.api import plugin
 
-class CreateWorkfile(plugin.ZbrushAutoCreator):
+class CreateWorkfile(plugin.SpeedTreeAutoCreator):
     """Workfile auto-creator."""
     identifier = "io.ayon.creators.speedtree.workfile"
     label = "Workfile"

--- a/client/ayon_speedtree/plugins/create/create_workfile.py
+++ b/client/ayon_speedtree/plugins/create/create_workfile.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Creator plugin for creating workfiles."""
+import ayon_api
+from ayon_core.pipeline import CreatedInstance
+from ayon_speedtree.api import plugin
+
+class CreateWorkfile(plugin.ZbrushAutoCreator):
+    """Workfile auto-creator."""
+    identifier = "io.ayon.creators.speedtree.workfile"
+    label = "Workfile"
+    product_type = "workfile"
+    icon = "fa5.file"
+
+    default_variant = "Main"
+
+    def create(self):
+        variant = self.default_variant
+        current_instance = next(
+            (
+                instance for instance in self.create_context.instances
+                if instance.creator_identifier == self.identifier
+            ), None)
+        project_name = self.project_name
+        folder_path = self.create_context.get_current_folder_path()
+        task_name = self.create_context.get_current_task_name()
+        host_name = self.create_context.host_name
+
+        if current_instance is None:
+            current_instance_asset = None
+        else:
+            current_instance_asset = current_instance["folderPath"]
+
+        if current_instance is None:
+            folder_entity = ayon_api.get_folder_by_path(
+                project_name, folder_path
+            )
+            task_entity = ayon_api.get_task_by_name(
+                project_name, folder_entity["id"], task_name
+            )
+            product_name = self.get_product_name(
+                project_name,
+                folder_entity,
+                task_entity,
+                variant,
+                host_name,
+            )
+            data = {
+                "task": task_name,
+                "variant": variant,
+                "folderPath": folder_path,
+            }
+
+            new_instance = CreatedInstance(
+                self.product_type, product_name, data, self
+            )
+            instances_data = self.host.list_instances()
+            instances_data.append(new_instance.data_to_store())
+            self.host.write_instances(instances_data)
+            self._add_instance_to_context(new_instance)
+
+        elif (
+            current_instance_asset != folder_path
+            or current_instance["task"] != task_name
+        ):
+            # Update instance context if is not the same
+            folder_entity = ayon_api.get_folder_by_path(
+                project_name, folder_path
+            )
+            task_entity = ayon_api.get_task_by_name(
+                project_name, folder_entity["id"], task_name
+            )
+            product_name = self.get_product_name(
+                variant, task_entity, folder_entity, project_name, host_name
+            )
+            current_instance["folderPath"] = folder_path
+            current_instance["task"] = task_entity["name"]
+            current_instance["productName"] = product_name

--- a/client/ayon_speedtree/plugins/load/load_workfile.py
+++ b/client/ayon_speedtree/plugins/load/load_workfile.py
@@ -86,4 +86,5 @@ class WorkfileLoader(load.LoaderPlugin):
 
         filename = work_template["file"].format_strict(data)
         path = os.path.join(work_root, filename)
+        os.environ["CURRENT_SPM"] = file_path
         host.save_workfile(path)

--- a/client/ayon_speedtree/plugins/load/load_workfile.py
+++ b/client/ayon_speedtree/plugins/load/load_workfile.py
@@ -1,0 +1,89 @@
+import os
+from ayon_core.pipeline import load
+from ayon_core.pipeline import (
+    registered_host,
+    get_current_context,
+    Anatomy,
+)
+from ayon_core.pipeline.workfile import (
+    get_workfile_template_key_from_context,
+    get_last_workfile_with_version,
+)
+from ayon_core.pipeline.template_data import get_template_data_with_names
+from ayon_speedtree.api.pipeline import get_current_workfile_context
+
+from ayon_core.pipeline.version_start import get_versioning_start
+
+
+class WorkfileLoader(load.LoaderPlugin):
+    """SpeedTree Workfile Loader."""
+
+    product_types = {"workfile"}
+    representations = {"spm"}
+    order = -9
+    icon = "code-fork"
+    color = "white"
+    label = "Load Workfile"
+
+    def load(self, context, name=None, namespace=None, data=None):
+        file_path = os.path.normpath(
+            self.filepath_from_context(context)
+        )
+        if not os.path.exists(file_path):
+            raise FileExistsError("The loaded file not found.")
+
+
+        host = registered_host()
+        work_context = get_current_workfile_context()
+        project_name = work_context.get("project_name")
+        folder_path = work_context.get("folder_path")
+        task_name = work_context.get("task_name")
+
+        if not folder_path:
+            current_context = get_current_context()
+            project_name = current_context.get("project_name")
+            folder_path = current_context.get("folder_path")
+            task_name = current_context.get("task_name")
+
+        host_name = "speedtree"
+        template_key = get_workfile_template_key_from_context(
+            project_name,
+            folder_path,
+            task_name,
+            host_name,
+        )
+        anatomy = Anatomy(project_name)
+
+        data = get_template_data_with_names(
+            project_name, folder_path, task_name, host_name
+        )
+
+        data["root"] = anatomy.roots
+
+        work_template = anatomy.get_template_item("work", template_key)
+
+        extensions = host.get_workfile_extensions()
+        extension = extensions[0]
+        data["ext"] = extension.lstrip(".")
+
+        work_root = work_template["directory"].format_strict(data)
+        version = get_last_workfile_with_version(
+            work_root, work_template["file"].template, data, extensions
+        )[1]
+
+        if version is None:
+            version = get_versioning_start(
+                project_name,
+                "tvpaint",
+                task_name=task_name,
+                task_type=data["task"]["type"],
+                product_type="workfile"
+            )
+        else:
+            version += 1
+
+        data["version"] = version
+
+        filename = work_template["file"].format_strict(data)
+        path = os.path.join(work_root, filename)
+        host.save_workfile(path)

--- a/client/ayon_speedtree/plugins/publish/collect_current_file.py
+++ b/client/ayon_speedtree/plugins/publish/collect_current_file.py
@@ -1,0 +1,17 @@
+
+import pyblish.api
+from ayon_core.pipeline import registered_host
+
+
+class CollectCurrentFile(pyblish.api.ContextPlugin):
+    label = "Collect Current File"
+    order = pyblish.api.CollectorOrder - 0.4
+    hosts = ["speedtree"]
+
+    def process(self, context):
+        host = registered_host()
+        current_file = host.get_current_workfile()
+        if not current_file:
+            self.log.error("Scene is not saved. Please save the "
+                           "scene with AYON workfile tools.")
+        context.data["currentFile"] = current_file

--- a/client/ayon_speedtree/plugins/publish/collect_workfile.py
+++ b/client/ayon_speedtree/plugins/publish/collect_workfile.py
@@ -1,0 +1,32 @@
+import os
+import json
+import pyblish.api
+
+
+class CollectWorkfile(pyblish.api.InstancePlugin):
+    label = "Collect Workfile"
+    order = pyblish.api.CollectorOrder - 0.4
+    hosts = ["speedtree"]
+    families = ["workfile"]
+
+    def process(self, instance):
+        context = instance.context
+        current_file = context.data["currentFile"]
+
+        self.log.info(
+            "Workfile path used for workfile family: {}".format(current_file)
+        )
+
+        dirpath, filename = os.path.split(current_file)
+        basename, ext = os.path.splitext(filename)
+
+        instance.data["representations"].append({
+            "name": ext.lstrip("."),
+            "ext": ext.lstrip("."),
+            "files": filename,
+            "stagingDir": dirpath
+        })
+
+        self.log.info("Collected workfile instance: {}".format(
+            json.dumps(instance.data, indent=4)
+        ))

--- a/client/ayon_speedtree/plugins/publish/extract_model.py
+++ b/client/ayon_speedtree/plugins/publish/extract_model.py
@@ -4,7 +4,7 @@ from ayon_core.pipeline import publish
 from ayon_core.pipeline.publish import (
     AYONPyblishPluginMixin
 )
-from ayon_speedtree.api.lib import save_scene
+from ayon_speedtree.api.lib import save_scene, export_model
 
 
 
@@ -24,12 +24,15 @@ class ExtractModel(publish.Extractor,
         stagingdir = self.staging_dir(instance)
         fbx_filename = f"{instance.name}.fbx"
         fbx_filepath = os.path.join(stagingdir, fbx_filename)
+        fbx_filepath = os.path.normpath(fbx_filepath)
 
         xml_filename = f"{instance.name}.xml"
         xml_filepath = os.path.join(stagingdir, xml_filename)
-        # TODO: implement the export code.
+        xml_filepath = os.path.normpath(xml_filepath)
+
         with save_scene("Ayon Publisher"):
-            pass
+            current_file = instance.context.data["current_file"]
+            export_model(current_file, fbx_filepath, xml_filepath)
 
         if "representations" not in instance.data:
             instance.data["representations"] = []

--- a/client/ayon_speedtree/plugins/publish/extract_model.py
+++ b/client/ayon_speedtree/plugins/publish/extract_model.py
@@ -31,7 +31,7 @@ class ExtractModel(publish.Extractor,
         xml_filepath = os.path.normpath(xml_filepath)
 
         with save_scene("Ayon Publisher"):
-            current_file = instance.context.data["current_file"]
+            current_file = instance.context.data["currentFile"]
             export_model(current_file, fbx_filepath, xml_filepath)
 
         if "representations" not in instance.data:

--- a/client/ayon_speedtree/plugins/publish/extract_model.py
+++ b/client/ayon_speedtree/plugins/publish/extract_model.py
@@ -1,0 +1,56 @@
+import os
+import pyblish.api
+from ayon_core.pipeline import publish
+from ayon_core.pipeline.publish import (
+    AYONPyblishPluginMixin
+)
+from ayon_speedtree.api.lib import save_scene
+
+
+
+class ExtractModel(publish.Extractor,
+                   AYONPyblishPluginMixin):
+    """
+    Extract PolyMesh(.fbx, .xml) in SpeedTree
+    """
+
+    order = pyblish.api.ExtractorOrder - 0.05
+    label = "Extract Model"
+    hosts = ["speedtree"]
+    families = ["model"]
+
+    def process(self, instance):
+
+        stagingdir = self.staging_dir(instance)
+        fbx_filename = f"{instance.name}.fbx"
+        fbx_filepath = os.path.join(stagingdir, fbx_filename)
+
+        xml_filename = f"{instance.name}.xml"
+        xml_filepath = os.path.join(stagingdir, xml_filename)
+        # TODO: implement the export code.
+        with save_scene("Ayon Publisher"):
+            pass
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+        fbx_representation = {
+        "name": "fbx",
+        "ext": "fbx",
+        "files": fbx_filename,
+        "stagingDir": stagingdir,
+        }
+        xml_representation = {
+        "name": "xml",
+        "ext": "xml",
+        "files": xml_filename,
+        "stagingDir": stagingdir,
+        }
+        instance.data["representations"].extend(
+            [fbx_representation, xml_representation]
+        )
+        self.log.info(
+            "Extracted instance '%s' to: %s" % (instance.name, fbx_filepath)
+        )
+        self.log.info(
+            "Extracted instance '%s' to: %s" % (instance.name, xml_filepath)
+        )

--- a/client/ayon_speedtree/plugins/publish/increment_workfile_version.py
+++ b/client/ayon_speedtree/plugins/publish/increment_workfile_version.py
@@ -1,0 +1,18 @@
+import pyblish.api
+from ayon_core.lib import version_up
+from ayon_core.pipeline import registered_host
+
+
+class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
+    """Save current file"""
+
+    label = "Save current file"
+    order = pyblish.api.ExtractorOrder - 0.49
+    hosts = ["speedtree"]
+    families = ["workfile"]
+
+    def process(self, context):
+        host = registered_host()
+        path = context.data["currentFile"]
+        self.log.info(f"Increment and save workfile: {path}")
+        host.save_workfile(version_up(path))

--- a/client/ayon_speedtree/version.py
+++ b/client/ayon_speedtree/version.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""Package declaring AYON addon 'speedtree' version."""
+__version__ = "0.1.0"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,0 +1,2 @@
+[ayon.runtimeDependencies]
+aiohttp_json_rpc = "*"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,2 +1,6 @@
+[project]
+name="speedtree"
+description="AYON Speedtree addon."
+
 [ayon.runtimeDependencies]
 aiohttp_json_rpc = "*"

--- a/package.py
+++ b/package.py
@@ -6,7 +6,7 @@ name = "speedtree"
 title = "SpeedTree"
 
 # Required: Valid semantic version (https://semver.org/)
-version = "0.0.0"
+version = "0.1.0"
 
 # Name of client code directory imported in AYON launcher
 # - do not specify if there is no client code

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,12 +2,12 @@ from typing import Type
 
 from ayon_server.addons import BaseServerAddon
 
-from .settings import MySettings, DEFAULT_VALUES
+from .settings import SpeedtreeSettings, DEFAULT_SPTREE_VALUES
 
 
-class MyAddon(BaseServerAddon):
-    settings_model: Type[MySettings] = MySettings
+class SpeedtreeAddon(BaseServerAddon):
+    settings_model: Type[SpeedtreeSettings] = SpeedtreeSettings
 
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
-        return settings_model_cls(**DEFAULT_VALUES)
+        return settings_model_cls(**DEFAULT_SPTREE_VALUES)

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,7 +1,25 @@
-from ayon_server.settings import BaseSettingsModel
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField,
 
-DEFAULT_SPTREE_VALUES = {}
+)
 
 
 class SpeedtreeSettings(BaseSettingsModel):
-    pass
+    sdk_directory: str = SettingsField(
+        "/path/to/bindings/python/python3.9/speedtree",
+        title="Pipeline SDK directory",
+        description=("The path to get the python binding folder "
+                     "to be used in SpeedTree Integration.")
+    )
+    template_path: str = SettingsField(
+        "", title="Custom Template Path",
+        description=("The path to get the custom template "
+                     "to be used in SpeedTree Integration.")
+    )
+
+
+DEFAULT_SPTREE_VALUES = {
+    "sdk_directory": "/path/to/bindings/python/python3.9/speedtree",
+    "template_path": ""
+}

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,7 +1,7 @@
 from ayon_server.settings import BaseSettingsModel
 
-DEFAULT_VALUES = {}
+DEFAULT_SPTREE_VALUES = {}
 
 
-class MySettings(BaseSettingsModel):
+class SpeedtreeSettings(BaseSettingsModel):
     pass


### PR DESCRIPTION
## Changelog Description
Initial Integration of Ayon plugins(Publisher, Workfile) into speedtree integration
Resolve https://github.com/ynput/ayon-speedtree/issues/1, https://github.com/ynput/ayon-speedtree/issues/3, https://github.com/ynput/ayon-speedtree/issues/4
Workfile tools(Saving and Loading)
https://github.com/user-attachments/assets/e5701d02-519b-42ff-b6e3-3d09ca8b86dd
https://github.com/user-attachments/assets/47526a67-f38a-48d7-9984-7065c2399a31

Publishing 

https://github.com/user-attachments/assets/49bd2d00-4bf1-41e0-87c6-cad66fe3ffaa



## Additional review information
**Before launching the integration:**
Make sure you have the correct SDK folder set in the ayon setting for ayon plugins before the launch
For example, If you unzipped your sdk folder into `D:/`, It should be `D:/speedtree_pipeline_sdk_10.0.1_win64/bindings/python/python3.9/speedtree`
If you have custom template (some custom spm file) to be used in SpeedTree. Please fill in `ayon+settings://speedtree/template_path` otherwise, it would use `Blank.spm` from the default game template folder instead.

**Limitation of Workfile tools/Publishing tools**
As the current speedtree API/command does not support single instance (one single executable) to load the file in terms of command, there would be temporarily closed for the previous spm file and load back the latest spm file when either saving or loading files action perform. 

**Load Action is not temporarily supported due to the limitation of API** and the spm file is being binary data(unlike Substance's xml). It is still possible to support the load Action but it would be not quite user-friendly...

## Testing notes:

1. Launch SpeedTree
2. Test the integration
