### PR TITLE
Use folderpath when updating dynamic data

### DIFF
--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -79,11 +79,13 @@ class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
     def get_dynamic_data(self, *args, **kwargs):
         # Change asset and name by current workfile context
         create_context = self.create_context
-        asset_name = create_context.get_current_folder_path()
+        folder_path = create_context.get_current_folder_path()
         task_name = create_context.get_current_task_name()
         output = {}
-        if asset_name:
-            output["asset"] = asset_name
+        if folder_path:
+            folder_name = folder_path.rsplit("/")[-1]
+            output["asset"] = folder_name
+            output["folder"] = {"name": folder_name}
             if task_name:
                 output["task"] = task_name
         return output


### PR DESCRIPTION
## Changelog Description
Use folderpath data instead of asset when updating dynamic data.

## Additional review information
n/a

## Testing notes:
1. Launch SpeedTree
2. Publish
