### PR TITLE
Update pre-launch hook script which copies speedtree pipeline sdk python binding 

### DIFF
--- a/client/ayon_speedtree/addon.py
+++ b/client/ayon_speedtree/addon.py
@@ -20,19 +20,6 @@ class SpeedtreeAddon(AYONAddon, IHostAddon):
     host_name = "speedtree"
 
     def add_implementation_envs(self, env, app):
-        new_python_paths = [
-            os.path.join(
-                SPTREE_ADDON_ROOT, "api", "sdk")
-        ]
-        old_python_path = env.get("PYTHONPATH") or ""
-        for path in old_python_path.split(os.pathsep):
-            if not path:
-                continue
-            norm_path = os.path.normpath(path)
-            if norm_path not in new_python_paths:
-                new_python_paths.append(norm_path)
-        env["PYTHONPATH"] = os.pathsep.join(new_python_paths)
-
         # Set default environments if are not set via settings
         defaults = {
             "AYON_LOG_NO_COLORS": "1",

--- a/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
+++ b/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
@@ -19,7 +19,7 @@ class SpeedtreeStartupScript(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def _get_version(self, sdk_folder: pathlib.Path):
-        site.addsitedir(sdk_folder.as_posix())
+        site.addsitedir(pathlib.Path(sdk_folder).as_posix())
         import speedtree.SpeedTree as SpeedTree
 
         return SpeedTree.__version__

--- a/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
+++ b/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """Pre-launch to copy SpeedTree Python Binding Script."""
 import os
+import pathlib
+import filecmp
+import site
+import stat
 import shutil
 from ayon_applications import PreLaunchHook, LaunchTypes
 from ayon_speedtree import SPTREE_ADDON_ROOT
@@ -14,6 +18,46 @@ class SpeedtreeStartupScript(PreLaunchHook):
     app_groups = {"speedtree"}
     launch_types = {LaunchTypes.local}
 
+    def _get_version(self, sdk_folder: pathlib.Path):
+        site.addsitedir(sdk_folder.as_posix())
+        import speedtree.SpeedTree as SpeedTree
+
+        return SpeedTree.__version__
+
+    def _sync_sdk_folder_by_perforce(self, sdk_folder: str):
+        try:
+            import ayon_perforce.api as perforce_api
+            perforce_api.sync(sdk_folder)
+            self.log.debug(
+                f"Sync the sdk folder:{sdk_folder} to Perforce."
+            )
+
+        except ImportError as err:
+            self.log.debug(f"Skip syncing folder to perforce as {err}")
+
+    def _force_copy_files(self, src: pathlib.Path, dst: pathlib.Path):
+        if dst.is_dir():
+            try:
+                shutil.copytree(src, dst)
+                return
+            except FileExistsError as error:
+                if (
+                    "Cannot create a file when that file already exists:"
+                    in str(error)
+                ):
+                    for sub_path in src.iterdir():
+                        self._force_copy_files(sub_path, dst / sub_path.name)
+
+                    return
+
+                raise
+
+        try:
+            shutil.copy(src, dst)
+        except PermissionError:
+            os.chmod(str(dst), stat.S_IWRITE)
+            shutil.copy(src, dst)
+
     def execute(self):
         speedtree_settings = self.data["project_settings"]["speedtree"]
         sdk_folder = os.path.normpath(
@@ -23,17 +67,39 @@ class SpeedtreeStartupScript(PreLaunchHook):
             raise RuntimeError(
                 "Directory not found. Fail to copy the "
                 "SDK python binding folder.")
+
+        version = self._get_version(sdk_folder)
         dst_folder = os.path.join(
-            SPTREE_ADDON_ROOT, "api", "sdk", "speedtree"
+            SPTREE_ADDON_ROOT, "api", "sdk", "speedtree", version
         )
-        if os.path.exists(dst_folder):
+        self._sync_sdk_folder_by_perforce(sdk_folder)
+        python_env = self.launch_context.env["PYTHONPATH"]
+        paths = python_env.split(os.pathsep)
+        paths.append(dst_folder.as_posix())
+        self.launch_context.env["PYTHONPATH"] = os.pathsep.join(paths)
+        if dst_folder.exists():
+            filecmp.clear_cache()
+            if not filecmp.cmp(sdk_folder, dst_folder, shallow=False):
+                self.log.info(
+                    (
+                        "Local SpeedTree SDK folder already exists:\n"
+                        f"- {dst_folder}"
+                    )
+                )
+                return
+
             self.log.info(
-                "SpeedTree Python Binding Folder is already copied."
+                (
+                    "Local SpeedTree SDK folder exists but is out of date:\n"
+                    f"- {dst_folder}\n"
+                    "Force updating..."
+                )
             )
+            self._force_copy_files(sdk_folder, dst_folder)
             return
 
         shutil.copytree(sdk_folder, dst_folder)
         self.log.info(
             "SpeedTree Python binding folder "
-            f"copied from {sdk_folder} to {dst_folder}"
+            f"copied from {sdk_folder} -> {dst_folder}"
         )

--- a/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
+++ b/client/ayon_speedtree/hooks/copy_sdk_python_binding.py
@@ -69,9 +69,9 @@ class SpeedtreeStartupScript(PreLaunchHook):
                 "SDK python binding folder.")
 
         version = self._get_version(sdk_folder)
-        dst_folder = os.path.join(
+        dst_folder = pathlib.Path(os.path.join(
             SPTREE_ADDON_ROOT, "api", "sdk", "speedtree", version
-        )
+        ))
         self._sync_sdk_folder_by_perforce(sdk_folder)
         python_env = self.launch_context.env["PYTHONPATH"]
         paths = python_env.split(os.pathsep)

--- a/server/settings.py
+++ b/server/settings.py
@@ -20,6 +20,6 @@ class SpeedtreeSettings(BaseSettingsModel):
 
 
 DEFAULT_SPTREE_VALUES = {
-    "sdk_directory": "/path/to/bindings/python/python3.9/speedtree",
+    "sdk_directory": "/path/to/bindings/python/python3.9",
     "template_path": ""
 }


### PR DESCRIPTION
## Changelog Description
This PR is to adjust the pre-launch hook which copies the sdk python binding so that it can copy the python binding across different versions of Speedtree. The update also supports the perforce sync folder if you have Ayon Perforce addon installed.
Special thanks for contribution: @munkybutt 


## Additional review information
As Ayon is using 3.10, you need to re-complie and deploy your SpeedTree pipeline SDK to 3.10 instead of 3.9.

## Testing notes:
1. Build Addon with this brnach
2. Launch SpeedTree
3. Publishing should be working