### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -39,6 +39,7 @@ class SpeedtreeCreatorBase:
 
 
 class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
+    setting_category = "speedtree"
     skip_discovery = True
 
     def create(self, product_name, instance_data, pre_create_data):

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -78,21 +78,6 @@ class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
         for instance in instances:
             self._remove_instance_from_context(instance)
 
-    # Helper methods (this might get moved into Creator class)
-    def get_dynamic_data(self, *args, **kwargs):
-        # Change asset and name by current workfile context
-        create_context = self.create_context
-        folder_path = create_context.get_current_folder_path()
-        task_name = create_context.get_current_task_name()
-        output = {}
-        if folder_path:
-            folder_name = folder_path.rsplit("/")[-1]
-            output["asset"] = folder_name
-            output["folder"] = {"name": folder_name}
-            if task_name:
-                output["task"] = task_name
-        return output
-
     def _store_new_instance(self, new_instance):
         instances_data = self.host.list_instances()
         instances_data.append(new_instance.data_to_store())

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -39,6 +39,8 @@ class SpeedtreeCreatorBase:
 
 
 class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
+    skip_discovery = True
+    
     def create(self, product_name, instance_data, pre_create_data):
         product_type = instance_data.get("productType")
         if not product_type:

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -39,7 +39,7 @@ class SpeedtreeCreatorBase:
 
 
 class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
-    setting_category = "speedtree"
+    settings_category = "speedtree"
     skip_discovery = True
 
     def create(self, product_name, instance_data, pre_create_data):
@@ -89,6 +89,9 @@ class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
 
 
 class SpeedTreeAutoCreator(AutoCreator, SpeedtreeCreatorBase):
+    settings_category = "speedtree"
+    skip_discovery = True
+    
     def collect_instances(self):
         self._collect_instances()
 

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -40,8 +40,12 @@ class SpeedtreeCreatorBase:
 
 class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
     def create(self, product_name, instance_data, pre_create_data):
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         new_instance = CreatedInstance(
-            product_type=self.product_type,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             product_name=product_name,
             data=instance_data,
             creator=self

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -40,7 +40,7 @@ class SpeedtreeCreatorBase:
 
 class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
     skip_discovery = True
-    
+
     def create(self, product_name, instance_data, pre_create_data):
         product_type = instance_data.get("productType")
         if not product_type:

--- a/client/ayon_speedtree/api/plugin.py
+++ b/client/ayon_speedtree/api/plugin.py
@@ -91,7 +91,7 @@ class SpeedTreeCreator(Creator, SpeedtreeCreatorBase):
 class SpeedTreeAutoCreator(AutoCreator, SpeedtreeCreatorBase):
     settings_category = "speedtree"
     skip_discovery = True
-    
+
     def collect_instances(self):
         self._collect_instances()
 

--- a/client/ayon_speedtree/plugins/create/create_model.py
+++ b/client/ayon_speedtree/plugins/create/create_model.py
@@ -7,6 +7,6 @@ class CreateModel(plugin.SpeedTreeCreator):
     """Creator plugin for Model."""
     identifier = "io.ayon.creators.speedtree.model"
     label = "Model"
-    product_type = "model"
     product_base_type = "model"
+    product_type = product_base_type
     icon = "cube"

--- a/client/ayon_speedtree/plugins/create/create_workfile.py
+++ b/client/ayon_speedtree/plugins/create/create_workfile.py
@@ -8,8 +8,8 @@ class CreateWorkfile(plugin.SpeedTreeAutoCreator):
     """Workfile auto-creator."""
     identifier = "io.ayon.creators.speedtree.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "fa5.file"
 
     default_variant = "Main"

--- a/client/ayon_speedtree/plugins/create/create_workfile.py
+++ b/client/ayon_speedtree/plugins/create/create_workfile.py
@@ -44,6 +44,7 @@ class CreateWorkfile(plugin.SpeedTreeAutoCreator):
                 task_entity,
                 variant,
                 host_name,
+                product_type=self.product_type,
             )
             data = {
                 "task": task_name,
@@ -52,6 +53,7 @@ class CreateWorkfile(plugin.SpeedTreeAutoCreator):
             }
 
             new_instance = CreatedInstance(
+                product_base_type=self.product_base_type,
                 product_type=self.product_type,
                 product_name=product_name,
                 data=data,
@@ -74,7 +76,12 @@ class CreateWorkfile(plugin.SpeedTreeAutoCreator):
                 project_name, folder_entity["id"], task_name
             )
             product_name = self.get_product_name(
-                variant, task_entity, folder_entity, project_name, host_name
+                variant,
+                task_entity,
+                folder_entity,
+                project_name,
+                host_name,
+                product_type=self.product_type,
             )
             current_instance["folderPath"] = folder_path
             current_instance["task"] = task_entity["name"]

--- a/client/ayon_speedtree/plugins/load/load_workfile.py
+++ b/client/ayon_speedtree/plugins/load/load_workfile.py
@@ -56,7 +56,10 @@ class WorkfileLoader(load.LoaderPlugin):
         anatomy = Anatomy(project_name)
 
         data = get_template_data_with_names(
-            project_name, folder_path, task_name, host_name
+            project_name,
+            folder_path,
+            task_name,
+            host_name=host_name,
         )
 
         data["root"] = anatomy.roots
@@ -75,7 +78,7 @@ class WorkfileLoader(load.LoaderPlugin):
         if version is None:
             version = get_versioning_start(
                 project_name,
-                "tvpaint",
+                host_name,
                 task_name=task_name,
                 task_type=data["task"]["type"],
                 product_type="workfile"

--- a/client/ayon_speedtree/plugins/load/load_workfile.py
+++ b/client/ayon_speedtree/plugins/load/load_workfile.py
@@ -18,7 +18,8 @@ from ayon_core.pipeline.version_start import get_versioning_start
 class WorkfileLoader(load.LoaderPlugin):
     """SpeedTree Workfile Loader."""
 
-    product_types = {"workfile"}
+    product_base_types = {"workfile"}
+    product_types = product_base_types
     representations = {"spm"}
     order = -9
     icon = "code-fork"

--- a/package.py
+++ b/package.py
@@ -20,7 +20,7 @@ ayon_server_version = ">=1.1.2"
 # Mapping of addon name to version requirements
 # - addon with specified version range must exist to be able to use this addon
 ayon_required_addons = {
-    "core": ">=1.0.12",
+    "core": ">=1.8.0",
 }
 # Mapping of addon name to version requirements
 # - if addon is used in same bundle the version range must be valid

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,8 +1,38 @@
 from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
-
 )
+
+
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
+class CreateModelModel(BaseSettingsModel):
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
+
+
+class CreatPluginsModel(BaseSettingsModel):
+    CreateModel: CreateModelModel = SettingsField(
+        default_factory=CreateModelModel,
+        title="Create Model",
+        description="Creator for model product"
+    )
 
 
 class SpeedtreeSettings(BaseSettingsModel):
@@ -16,6 +46,10 @@ class SpeedtreeSettings(BaseSettingsModel):
         "", title="Custom Template Path",
         description=("The path to get the custom template "
                      "to be used in SpeedTree Integration.")
+    )
+    create: CreatPluginsModel = SettingsField(
+        default_factory=CreatPluginsModel,
+        title="Create Plugins",
     )
 
 


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Codebase of Speedtree addon is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

Model create plugin have option to define custom product types for plate instances.

Small changes/fixes
- Use correct host name.
- Removed 'get_dynamic_data' override adding `"asset"` and `"folder"` (`"asset"` is deprecated `"folder"` is added by core).

## Testing notes:
This is untested PR from my side, please make sure it is fully reviewed.
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Upload the addon to server to use new settings model.
3. Existing workfiles should load up and should be possible to publish.
4. Creating new instances should work as expected.

### Product types
1. Define product types for model in settings.
2. Publisher should show the product types you've defined.
3. Create them.
5. Product name should use the product type in name (if template defines that).
6. Publish the instances.
7. Loader tool should show the product type and product base type in UI.