### PR TITLE
Launch hook: Handle 'workfile_path' key in pre-launch hook

### DIFF
--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -5,7 +5,6 @@ from ayon_core.pipeline import tempdir
 from ayon_applications import (
     PreLaunchHook,
     LaunchTypes,
-    ApplicationLaunchFailed,
 )
 
 

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -1,14 +1,19 @@
 import os
 import shutil
-from ayon_applications import PreLaunchHook, LaunchTypes
+
 from ayon_core.pipeline import tempdir
+from ayon_applications import (
+    PreLaunchHook,
+    LaunchTypes,
+    ApplicationLaunchFailed,
+)
 
 
 class CreateTempSpmFile(PreLaunchHook):
     """Create Temp Spm File to SpeedTree.
 
     The temp spm file would be created in SpeedTree prior to
-    the launch of the software if there is no last workfile
+    the launch of the software if there is no workfile to launch.
 
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
@@ -17,24 +22,37 @@ class CreateTempSpmFile(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-        last_workfile = self.data.get("last_workfile_path")
-        if self.data.get("start_last_workfile")  \
-            and last_workfile  \
-                and os.path.exists(last_workfile):
+        workfile_path = self.get_workfile_path()
+
+        self.launch_context.launch_args.append(workfile_path)
+
+        self.launch_context.env["CURRENT_SPM"] = workfile_path
+
+    def get_workfile_path(self):
+        workfile_path = self.data.get("workfile_path")
+        if workfile_path:
+            if not os.path.exists(workfile_path):
+                raise ApplicationLaunchFailed(
+                    f"Workfile path '{workfile_path}' does not exist"
+                )
+            return workfile_path
+
+        if self.data.get("start_last_workfile"):
             self.log.info("It is set to start last workfile on start.")
-        else:
-            source_template_file = self.get_custom_template_path()
-            staging_dir = tempdir.get_temp_dir(
-                self.data["project_name"],
-                use_local_temp=True
-            )
-            spm_filename = os.path.basename(source_template_file)
-            last_workfile = os.path.join(staging_dir, spm_filename)
-            shutil.copyfile(source_template_file, last_workfile)
+            workfile_path = self.data.get("last_workfile_path")
 
-        self.launch_context.launch_args.append(last_workfile)
+        if workfile_path and os.path.exists(workfile_path):
+            return workfile_path
 
-        self.launch_context.env["CURRENT_SPM"] = last_workfile
+        source_template_file = self.get_custom_template_path()
+        staging_dir = tempdir.get_temp_dir(
+            self.data["project_name"],
+            use_local_temp=True
+        )
+        spm_filename = os.path.basename(source_template_file)
+        workfile_path = os.path.join(staging_dir, spm_filename)
+        shutil.copyfile(source_template_file, workfile_path)
+        return workfile_path
 
     def get_custom_template_path(self):
         speedtree_settings = self.data["project_settings"]["speedtree"]

--- a/client/ayon_speedtree/hooks/create_temp_spm_file.py
+++ b/client/ayon_speedtree/hooks/create_temp_spm_file.py
@@ -31,18 +31,13 @@ class CreateTempSpmFile(PreLaunchHook):
     def get_workfile_path(self):
         workfile_path = self.data.get("workfile_path")
         if workfile_path:
-            if not os.path.exists(workfile_path):
-                raise ApplicationLaunchFailed(
-                    f"Workfile path '{workfile_path}' does not exist"
-                )
             return workfile_path
 
         if self.data.get("start_last_workfile"):
             self.log.info("It is set to start last workfile on start.")
             workfile_path = self.data.get("last_workfile_path")
-
-        if workfile_path and os.path.exists(workfile_path):
-            return workfile_path
+            if workfile_path and os.path.exists(workfile_path):
+                return workfile_path
 
         source_template_file = self.get_custom_template_path()
         staging_dir = tempdir.get_temp_dir(


### PR DESCRIPTION
## Changelog Description
Handle `"workfile_path"` in prelaunch hook.

## Additional review information
If `"workfile_path"` is filled it means it should be used (e.g. was selected in launcher).

## Testing notes:
1. Speedtree workfiles can be launched from launcher tool.
